### PR TITLE
feat: add responsive home layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Replaced the Telegram/Matrix HTTP clients with queue-driven bridge facades for Telegram, Matrix, IRC, and XMPP plus a shared `ServiceBridge` helper and in-memory queue adapter tests.
 - Introduced a queue behaviour contract to standardise `bridge/<service>/<action>` envelopes with trace IDs for all connectors.
 - Updated bridge strategy, architecture, account linking, and platform research docs to focus on StoneMQ-backed daemons and MTProto-based Telegram support.
+- Redesignet Flutter-hjemmeskjermen med et responsivt oppsett for mobil, nettbrett og desktop, komplett med gradient-sidefelt, innboks-panel og handlingslinje.
+- La til widgettester for brytepunktene og dokumenterte strukturen i `docs/frontend_responsive.md`.
 ## [Unreleased]
 ### Added
 - Konsolidert produktplan og forskningsoppsummering med fokus på chat-MVP, identitet og arkitektur.

--- a/docs/frontend_responsive.md
+++ b/docs/frontend_responsive.md
@@ -1,0 +1,22 @@
+# Responsive Flutter shell
+
+Denne notatfilen beskriver hvordan den nye responsive hjemmeskjermen i Flutter-appen er strukturert.
+
+## Brytepunkt
+
+| Navn | Bredde | Layout |
+| ---- | ------ | ------ |
+| Kompakt | < 900 px | Enkeltkolonne med kategori-velger og chatkort |
+| Nettbrett | 900-1279 px | To kolonner med innboks-panel og samtalekort |
+| Desktop | >= 1280 px | Tre kolonner med gradient-sidefelt, innboks og samtalekort |
+
+## Oppbygning
+
+- `_HomeSidebar` gir et gradientpanel med handlinger for ny samtale, invitasjon og innstillinger.
+- `_HomeInboxPanel` viser søkefelt, filterchips og lister over rom og samtaler.
+- `_HomeActionStrip` tilbyr raske snarveier (meny, innstillinger, invitasjon, nytt rom, ny samtale).
+- `_HomeChatPanel` legger inn `ChatPage` i et kort med avrundede hjørner og skygge på større skjermer.
+
+## Tester
+
+Widget-testen `home_page_test.dart` dekker brytepunktene slik at fremtidige endringer holder layouten responsiv.

--- a/flutter_frontend/lib/ui/pages/home_page/home_page.dart
+++ b/flutter_frontend/lib/ui/pages/home_page/home_page.dart
@@ -4,7 +4,10 @@ import 'package:messngr/redux/app_state.dart';
 import 'package:messngr/redux/navigation/navigation_actions.dart';
 import 'package:messngr/ui/widgets/CategorySelector.dart';
 import 'package:messngr/features/chat/chat_page.dart';
+import 'package:messngr/ui/widgets/conversation/conversations_list_widget.dart';
+import 'package:messngr/ui/widgets/room/room_list_widget.dart';
 import 'package:messngr/utils/flutter_redux.dart';
+import 'package:redux/redux.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -14,70 +17,738 @@ class HomePage extends StatefulWidget {
 }
 
 class HomePageState extends State<HomePage> {
+  static const double _tabletBreakpoint = 900;
+  static const double _desktopBreakpoint = 1280;
+
+  final List<String> _categories = const [
+    'Direkte',
+    'Teamkanaler',
+    'Favoritter',
+    'Arkiv',
+  ];
+
+  int _selectedCategory = 0;
+
+  void _handleCategoryChanged(int index) {
+    if (_selectedCategory != index) {
+      setState(() {
+        _selectedCategory = index;
+      });
+    }
+  }
+
+  void _openSettings(Store<AppState> store) {
+    store.dispatch(
+      NavigateShellToNewRouteAction(route: AppNavigation.settingsPath),
+    );
+  }
+
+  void _openInvite(Store<AppState> store) {
+    store.dispatch(
+      NavigateShellToNewRouteAction(route: AppNavigation.inviteMemberPath),
+    );
+  }
+
+  void _createRoom(Store<AppState> store) {
+    final teamName = store.state.authState.currentTeamName;
+    if (teamName == null) {
+      return;
+    }
+    store.dispatch(NavigateShellToNewRouteAction(
+        route: AppNavigation.createRoomPath + teamName, kUsePush: true));
+  }
+
+  void _createConversation(Store<AppState> store) {
+    final teamName = store.state.authState.currentTeamName;
+    if (teamName == null) {
+      return;
+    }
+    store.dispatch(NavigateShellToNewRouteAction(
+        route: AppNavigation.createConversationPath + teamName,
+        kUsePush: true));
+  }
+
+  void _openDrawer() {
+    Scaffold.maybeOf(context)?.openDrawer();
+  }
+
   @override
   Widget build(BuildContext context) {
     final store = StoreProvider.of<AppState>(context);
-    return Column(
-      children: <Widget>[
-        const CategorySelector(),
-        Expanded(
-          child: Container(
-            decoration: BoxDecoration(
-              color: Theme.of(context).hintColor,
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth >= _desktopBreakpoint) {
+          return _HomeDesktopLayout(
+            store: store,
+            categories: _categories,
+            selectedCategory: _selectedCategory,
+            onCategorySelected: _handleCategoryChanged,
+            onInvite: () => _openInvite(store),
+            onSettings: () => _openSettings(store),
+            onCreateRoom: () => _createRoom(store),
+            onCreateConversation: () => _createConversation(store),
+            onOpenDrawer: _openDrawer,
+          );
+        }
+
+        if (constraints.maxWidth >= _tabletBreakpoint) {
+          return _HomeTabletLayout(
+            store: store,
+            categories: _categories,
+            selectedCategory: _selectedCategory,
+            onCategorySelected: _handleCategoryChanged,
+            onInvite: () => _openInvite(store),
+            onSettings: () => _openSettings(store),
+            onCreateRoom: () => _createRoom(store),
+            onCreateConversation: () => _createConversation(store),
+            onOpenDrawer: _openDrawer,
+          );
+        }
+
+        return _HomeCompactLayout(
+          store: store,
+          categories: _categories,
+          selectedCategory: _selectedCategory,
+          onCategorySelected: _handleCategoryChanged,
+          onInvite: () => _openInvite(store),
+          onSettings: () => _openSettings(store),
+          onCreateRoom: () => _createRoom(store),
+          onCreateConversation: () => _createConversation(store),
+          onOpenDrawer: _openDrawer,
+        );
+      },
+    );
+  }
+}
+
+class _HomeCompactLayout extends StatelessWidget {
+  const _HomeCompactLayout({
+    required this.store,
+    required this.categories,
+    required this.selectedCategory,
+    required this.onCategorySelected,
+    required this.onInvite,
+    required this.onSettings,
+    required this.onCreateRoom,
+    required this.onCreateConversation,
+    required this.onOpenDrawer,
+  });
+
+  final Store<AppState> store;
+  final List<String> categories;
+  final int selectedCategory;
+  final ValueChanged<int> onCategorySelected;
+  final VoidCallback onInvite;
+  final VoidCallback onSettings;
+  final VoidCallback onCreateRoom;
+  final VoidCallback onCreateConversation;
+  final VoidCallback onOpenDrawer;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      key: const Key('home_compact_layout'),
+      color: theme.colorScheme.surfaceVariant.withOpacity(0.25),
+      child: Column(
+        children: [
+          CategorySelector(
+            categories: categories,
+            initialIndex: selectedCategory,
+            onCategorySelected: onCategorySelected,
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+              child: Column(
+                children: [
+                  _HomeActionStrip(
+                    onSettings: onSettings,
+                    onInvite: onInvite,
+                    onCreateRoom: onCreateRoom,
+                    onCreateConversation: onCreateConversation,
+                    onOpenDrawer: onOpenDrawer,
+                  ),
+                  const SizedBox(height: 16),
+                  Expanded(
+                    child: _HomeChatPanel(compact: true),
+                  ),
+                ],
+              ),
             ),
-            child: Column(
-              children: <Widget>[
-                Row(
-                  children: [
-                    IconButton(
-                        onPressed: () {
-                          StoreProvider.of<AppState>(context).dispatch(
-                              NavigateShellToNewRouteAction(
-                                  route: AppNavigation.settingsPath));
-                        },
-                        icon: const Icon(Icons.settings)),
-                    IconButton(
-                      icon: const Icon(Icons.menu),
-                      onPressed: () {
-                        Scaffold.of(context).openDrawer();
-                      },
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.add_reaction_outlined),
-                      onPressed: () {
-                        StoreProvider.of<AppState>(context).dispatch(
-                            NavigateShellToNewRouteAction(
-                                route: AppNavigation.inviteMemberPath));
-                      },
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.add_comment),
-                      onPressed: () {
-                        StoreProvider.of<AppState>(context).dispatch(
-                            NavigateShellToNewRouteAction(
-                                route: AppNavigation.createRoomPath +
-                                    store.state.authState.currentTeamName!,
-                                kUsePush: true));
-                      },
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.maps_ugc),
-                      onPressed: () {
-                        StoreProvider.of<AppState>(context).dispatch(
-                            NavigateShellToNewRouteAction(
-                                route: AppNavigation.createConversationPath +
-                                    store.state.authState.currentTeamName!,
-                                kUsePush: true));
-                      },
-                    ),
-                  ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HomeTabletLayout extends StatelessWidget {
+  const _HomeTabletLayout({
+    required this.store,
+    required this.categories,
+    required this.selectedCategory,
+    required this.onCategorySelected,
+    required this.onInvite,
+    required this.onSettings,
+    required this.onCreateRoom,
+    required this.onCreateConversation,
+    required this.onOpenDrawer,
+  });
+
+  final Store<AppState> store;
+  final List<String> categories;
+  final int selectedCategory;
+  final ValueChanged<int> onCategorySelected;
+  final VoidCallback onInvite;
+  final VoidCallback onSettings;
+  final VoidCallback onCreateRoom;
+  final VoidCallback onCreateConversation;
+  final VoidCallback onOpenDrawer;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      key: const Key('home_medium_layout'),
+      color: theme.colorScheme.surfaceVariant.withOpacity(0.2),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 1200),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                SizedBox(
+                  width: 340,
+                  child: _HomeInboxPanel(
+                    store: store,
+                    categories: categories,
+                    selectedCategory: selectedCategory,
+                    onCategorySelected: onCategorySelected,
+                    onCreateConversation: onCreateConversation,
+                    onCreateRoom: onCreateRoom,
+                  ),
                 ),
-                const Expanded(child: ChatPage()),
+                const SizedBox(width: 24),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      _HomeActionStrip(
+                        onSettings: onSettings,
+                        onInvite: onInvite,
+                        onCreateRoom: onCreateRoom,
+                        onCreateConversation: onCreateConversation,
+                        onOpenDrawer: onOpenDrawer,
+                      ),
+                      const SizedBox(height: 16),
+                      Expanded(child: _HomeChatPanel()),
+                    ],
+                  ),
+                ),
               ],
             ),
           ),
         ),
-      ],
+      ),
+    );
+  }
+}
+
+class _HomeDesktopLayout extends StatelessWidget {
+  const _HomeDesktopLayout({
+    required this.store,
+    required this.categories,
+    required this.selectedCategory,
+    required this.onCategorySelected,
+    required this.onInvite,
+    required this.onSettings,
+    required this.onCreateRoom,
+    required this.onCreateConversation,
+    required this.onOpenDrawer,
+  });
+
+  final Store<AppState> store;
+  final List<String> categories;
+  final int selectedCategory;
+  final ValueChanged<int> onCategorySelected;
+  final VoidCallback onInvite;
+  final VoidCallback onSettings;
+  final VoidCallback onCreateRoom;
+  final VoidCallback onCreateConversation;
+  final VoidCallback onOpenDrawer;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      key: const Key('home_large_layout'),
+      color: theme.colorScheme.surfaceVariant.withOpacity(0.25),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 1440),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 32),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _HomeSidebar(
+                  categories: categories,
+                  selectedCategory: selectedCategory,
+                  onCategorySelected: onCategorySelected,
+                  onCreateConversation: onCreateConversation,
+                  onInvite: onInvite,
+                  onSettings: onSettings,
+                ),
+                const SizedBox(width: 28),
+                SizedBox(
+                  width: 360,
+                  child: _HomeInboxPanel(
+                    store: store,
+                    onCreateConversation: onCreateConversation,
+                    onCreateRoom: onCreateRoom,
+                  ),
+                ),
+                const SizedBox(width: 32),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      _HomeActionStrip(
+                        onSettings: onSettings,
+                        onInvite: onInvite,
+                        onCreateRoom: onCreateRoom,
+                        onCreateConversation: onCreateConversation,
+                        dense: true,
+                        onOpenDrawer: onOpenDrawer,
+                      ),
+                      const SizedBox(height: 18),
+                      Expanded(child: _HomeChatPanel()),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeSidebar extends StatelessWidget {
+  const _HomeSidebar({
+    required this.categories,
+    required this.selectedCategory,
+    required this.onCategorySelected,
+    required this.onCreateConversation,
+    required this.onInvite,
+    required this.onSettings,
+  });
+
+  final List<String> categories;
+  final int selectedCategory;
+  final ValueChanged<int> onCategorySelected;
+  final VoidCallback onCreateConversation;
+  final VoidCallback onInvite;
+  final VoidCallback onSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      key: const Key('home_large_sidebar'),
+      width: 260,
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            theme.colorScheme.primary,
+            theme.colorScheme.secondary,
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(32),
+        boxShadow: [
+          BoxShadow(
+            color: theme.colorScheme.primary.withOpacity(0.32),
+            blurRadius: 42,
+            offset: const Offset(0, 24),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Messngr',
+            style: theme.textTheme.headlineSmall?.copyWith(
+              color: Colors.white,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.6,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Snakk sammen, hvor som helst',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: Colors.white.withOpacity(0.76),
+            ),
+          ),
+          const SizedBox(height: 32),
+          CategorySelector(
+            categories: categories,
+            initialIndex: selectedCategory,
+            onCategorySelected: onCategorySelected,
+            scrollDirection: Axis.vertical,
+            backgroundColor: Colors.transparent,
+          ),
+          const Spacer(),
+          _SidebarButton(
+            icon: Icons.add_comment_rounded,
+            label: 'Ny chat',
+            onPressed: onCreateConversation,
+          ),
+          const SizedBox(height: 12),
+          _SidebarButton(
+            icon: Icons.group_add_rounded,
+            label: 'Inviter',
+            onPressed: onInvite,
+          ),
+          const SizedBox(height: 12),
+          _SidebarButton(
+            icon: Icons.settings_outlined,
+            label: 'Innstillinger',
+            onPressed: onSettings,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SidebarButton extends StatelessWidget {
+  const _SidebarButton({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton.icon(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Colors.white,
+          foregroundColor: Theme.of(context).colorScheme.primary,
+          padding: const EdgeInsets.symmetric(vertical: 14),
+          textStyle: const TextStyle(fontWeight: FontWeight.w600),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+          elevation: 0,
+        ),
+        icon: Icon(icon),
+        label: Text(label),
+      ),
+    );
+  }
+}
+
+class _HomeInboxPanel extends StatelessWidget {
+  const _HomeInboxPanel({
+    required this.store,
+    required this.onCreateConversation,
+    required this.onCreateRoom,
+    this.categories,
+    this.selectedCategory,
+    this.onCategorySelected,
+  });
+
+  final Store<AppState> store;
+  final VoidCallback onCreateConversation;
+  final VoidCallback onCreateRoom;
+  final List<String>? categories;
+  final int? selectedCategory;
+  final ValueChanged<int>? onCategorySelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      key: const Key('home_inbox_panel'),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(28),
+        boxShadow: [
+          BoxShadow(
+            color: theme.shadowColor.withOpacity(0.08),
+            blurRadius: 28,
+            offset: const Offset(0, 18),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Innboks',
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              FilledButton.icon(
+                onPressed: onCreateConversation,
+                icon: const Icon(Icons.chat_rounded),
+                label: const Text('Ny'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            decoration: InputDecoration(
+              hintText: 'Søk i samtaler',
+              prefixIcon: const Icon(Icons.search_rounded),
+              filled: true,
+              fillColor: theme.colorScheme.surfaceVariant.withOpacity(0.35),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(18),
+                borderSide: BorderSide.none,
+              ),
+              contentPadding: const EdgeInsets.symmetric(vertical: 0),
+            ),
+          ),
+          if (categories != null &&
+              selectedCategory != null &&
+              onCategorySelected != null) ...[
+            const SizedBox(height: 20),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (var i = 0; i < categories!.length; i++)
+                  ChoiceChip(
+                    label: Text(categories![i]),
+                    selected: selectedCategory == i,
+                    onSelected: (_) => onCategorySelected!(i),
+                    selectedColor: theme.colorScheme.primary.withOpacity(0.2),
+                    labelStyle: theme.textTheme.labelLarge?.copyWith(
+                      color: selectedCategory == i
+                          ? theme.colorScheme.primary
+                          : theme.colorScheme.onSurfaceVariant,
+                    ),
+                    backgroundColor:
+                        theme.colorScheme.surfaceVariant.withOpacity(0.2),
+                  ),
+              ],
+            ),
+          ],
+          const SizedBox(height: 24),
+          Expanded(
+            child: ScrollConfiguration(
+              behavior: const ScrollBehavior().copyWith(overscroll: false),
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    RoomListWidget(
+                      context: context,
+                      rooms: store.state.teamState?.rooms ?? [],
+                      store: store,
+                    ),
+                    const SizedBox(height: 24),
+                    ConversationsListWidget(
+                      context: context,
+                      conversations:
+                          store.state.teamState?.conversations ?? [],
+                      store: store,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              onPressed: onCreateRoom,
+              icon: const Icon(Icons.add_circle_outline),
+              label: const Text('Nytt rom'),
+              style: OutlinedButton.styleFrom(
+                padding:
+                    const EdgeInsets.symmetric(vertical: 14, horizontal: 18),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HomeActionStrip extends StatelessWidget {
+  const _HomeActionStrip({
+    required this.onSettings,
+    required this.onInvite,
+    required this.onCreateRoom,
+    required this.onCreateConversation,
+    required this.onOpenDrawer,
+    this.dense = false,
+  });
+
+  final VoidCallback onSettings;
+  final VoidCallback onInvite;
+  final VoidCallback onCreateRoom;
+  final VoidCallback onCreateConversation;
+  final VoidCallback onOpenDrawer;
+  final bool dense;
+
+  @override
+  Widget build(BuildContext context) {
+    final buttonPadding = dense
+        ? const EdgeInsets.symmetric(horizontal: 14)
+        : const EdgeInsets.symmetric(horizontal: 18);
+
+    return Container(
+      key: dense ? const Key('home_action_strip_dense') : const Key('home_action_strip'),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: Theme.of(context).shadowColor.withOpacity(0.08),
+            blurRadius: 18,
+            offset: const Offset(0, 12),
+          )
+        ],
+      ),
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+      child: Wrap(
+        alignment: WrapAlignment.spaceBetween,
+        runSpacing: 8,
+        spacing: 8,
+        children: [
+          _ActionChip(
+            icon: Icons.menu_rounded,
+            label: 'Meny',
+            onPressed: onOpenDrawer,
+            padding: buttonPadding,
+          ),
+          _ActionChip(
+            icon: Icons.settings_outlined,
+            label: 'Innstillinger',
+            onPressed: onSettings,
+            padding: buttonPadding,
+          ),
+          _ActionChip(
+            icon: Icons.group_add_rounded,
+            label: 'Inviter',
+            onPressed: onInvite,
+            padding: buttonPadding,
+          ),
+          _ActionChip(
+            icon: Icons.meeting_room_outlined,
+            label: 'Nytt rom',
+            onPressed: onCreateRoom,
+            padding: buttonPadding,
+          ),
+          _ActionChip(
+            icon: Icons.chat_rounded,
+            label: 'Ny samtale',
+            onPressed: onCreateConversation,
+            padding: buttonPadding,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActionChip extends StatelessWidget {
+  const _ActionChip({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+    required this.padding,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onPressed;
+  final EdgeInsets padding;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton.icon(
+      onPressed: onPressed,
+      icon: Icon(icon, size: 20),
+      label: Text(label),
+      style: ElevatedButton.styleFrom(
+        padding: padding,
+        elevation: 0,
+        backgroundColor:
+            Theme.of(context).colorScheme.primary.withOpacity(0.08),
+        foregroundColor: Theme.of(context).colorScheme.primary,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20),
+        ),
+        textStyle: const TextStyle(fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}
+
+class _HomeChatPanel extends StatelessWidget {
+  const _HomeChatPanel({this.compact = false});
+
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final borderRadius = BorderRadius.circular(compact ? 24 : 36);
+
+    return Container(
+      key: compact ? const Key('home_chat_panel_compact') : const Key('home_chat_panel'),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: borderRadius,
+        boxShadow: compact
+            ? []
+            : [
+                BoxShadow(
+                  color: theme.shadowColor.withOpacity(0.12),
+                  blurRadius: 32,
+                  offset: const Offset(0, 24),
+                ),
+              ],
+      ),
+      child: ClipRRect(
+        borderRadius: borderRadius,
+        child: const ChatPage(),
+      ),
     );
   }
 }

--- a/flutter_frontend/lib/ui/widgets/CategorySelector.dart
+++ b/flutter_frontend/lib/ui/widgets/CategorySelector.dart
@@ -1,45 +1,130 @@
 import 'package:flutter/material.dart';
 
 class CategorySelector extends StatefulWidget {
-  const CategorySelector({super.key});
+  const CategorySelector({
+    super.key,
+    this.categories = const ['Messages', 'Online', 'Groups', 'Requests'],
+    this.initialIndex,
+    this.onCategorySelected,
+    this.backgroundColor,
+    this.scrollDirection = Axis.horizontal,
+    this.padding = const EdgeInsets.symmetric(horizontal: 20.0, vertical: 30.0),
+  });
+
+  final List<String> categories;
+  final int? initialIndex;
+  final ValueChanged<int>? onCategorySelected;
+  final Color? backgroundColor;
+  final Axis scrollDirection;
+  final EdgeInsets padding;
 
   @override
-  _CategorySelectorState createState() => _CategorySelectorState();
+  State<CategorySelector> createState() => _CategorySelectorState();
 }
 
 class _CategorySelectorState extends State<CategorySelector> {
-  int selectedIndex = 0;
-  final List<String> categories = ['Messages', 'Online', 'Groups', 'Requests'];
+  late int _selectedIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedIndex = widget.initialIndex ?? 0;
+  }
+
+  @override
+  void didUpdateWidget(covariant CategorySelector oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.initialIndex != null &&
+        widget.initialIndex != oldWidget.initialIndex &&
+        widget.initialIndex != _selectedIndex) {
+      _selectedIndex = widget.initialIndex!;
+    }
+  }
+
+  void _handleTap(int index) {
+    if (widget.initialIndex == null) {
+      setState(() {
+        _selectedIndex = index;
+      });
+    }
+    widget.onCategorySelected?.call(index);
+  }
 
   @override
   Widget build(BuildContext context) {
+    final effectiveIndex = widget.initialIndex ?? _selectedIndex;
+    final backgroundColor =
+        widget.backgroundColor ?? Theme.of(context).primaryColor;
+
     return Container(
-      height: 90.0,
-      color: Theme.of(context).primaryColor,
+      height: widget.scrollDirection == Axis.horizontal ? 90.0 : null,
+      width: widget.scrollDirection == Axis.vertical ? double.infinity : null,
+      color: backgroundColor,
       child: ListView.builder(
-        scrollDirection: Axis.horizontal,
-        itemCount: categories.length,
+        shrinkWrap: widget.scrollDirection == Axis.vertical,
+        physics: widget.scrollDirection == Axis.vertical
+            ? const NeverScrollableScrollPhysics()
+            : null,
+        scrollDirection: widget.scrollDirection,
+        itemCount: widget.categories.length,
         itemBuilder: (BuildContext context, int index) {
+          final isSelected = index == effectiveIndex;
+          final text = widget.categories[index];
+
           return GestureDetector(
-            onTap: () {
-              setState(() {
-                selectedIndex = index;
-              });
-            },
+            onTap: () => _handleTap(index),
             child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 20.0,
-                vertical: 30.0,
-              ),
-              child: Text(
-                categories[index],
-                style: TextStyle(
-                  color: index == selectedIndex ? Colors.white : Colors.white60,
-                  fontSize: 24.0,
-                  fontWeight: FontWeight.bold,
-                  letterSpacing: 1.2,
-                ),
-              ),
+              padding: widget.scrollDirection == Axis.horizontal
+                  ? widget.padding
+                  : const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+              child: widget.scrollDirection == Axis.horizontal
+                  ? Text(
+                      text,
+                      style: TextStyle(
+                        color: isSelected ? Colors.white : Colors.white60,
+                        fontSize: 24.0,
+                        fontWeight: FontWeight.bold,
+                        letterSpacing: 1.2,
+                      ),
+                    )
+                  : AnimatedContainer(
+                      duration: const Duration(milliseconds: 200),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16.0, vertical: 12.0),
+                      decoration: BoxDecoration(
+                        color: isSelected
+                            ? Colors.white.withOpacity(0.16)
+                            : Colors.transparent,
+                        borderRadius: BorderRadius.circular(14.0),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Container(
+                            width: 8,
+                            height: 8,
+                            margin: const EdgeInsets.only(right: 12),
+                            decoration: BoxDecoration(
+                              color: isSelected
+                                  ? Colors.white
+                                  : Colors.white.withOpacity(0.4),
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                          Text(
+                            text,
+                            style: TextStyle(
+                              color: isSelected
+                                  ? Colors.white
+                                  : Colors.white.withOpacity(0.7),
+                              fontSize: 16.0,
+                              fontWeight: FontWeight.w600,
+                              letterSpacing: 0.4,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
             ),
           );
         },

--- a/flutter_frontend/lib/ui/widgets/conversation/conversations_list_item.dart
+++ b/flutter_frontend/lib/ui/widgets/conversation/conversations_list_item.dart
@@ -69,34 +69,42 @@ class _ConversationsListItemState extends State<ConversationsListItem> {
         padding: theme.data.padding,
         decoration: theme.data.decoration,
         child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Row(
-              children: <Widget>[
-                const SizedBox(width: 10.0),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Text(
-                      widget.conversation
-                          .conversationName(
-                              widget.store.state.teamState!.selectedTeam!.name)
-                          .toLowerCase(),
-                      style: theme.data.titleStyle,
+            Expanded(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  const SizedBox(width: 10.0),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          widget.conversation
+                              .conversationName(widget
+                                  .store
+                                  .state
+                                  .teamState!
+                                  .selectedTeam!
+                                  .name)
+                              .toLowerCase(),
+                          style: theme.data.titleStyle,
+                        ),
+                        const SizedBox(height: 5.0),
+                        Text(
+                          lastMsgString,
+                          style: theme.data.messagePreviewStyle,
+                          overflow: TextOverflow.ellipsis,
+                          maxLines: 1,
+                        ),
+                      ],
                     ),
-                    const SizedBox(height: 5.0),
-                    SizedBox(
-                      width: MediaQuery.of(context).size.width * 0.45,
-                      child: Text(
-                        lastMsgString,
-                        style: theme.data.messagePreviewStyle,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                  ],
-                ),
-              ],
+                  ),
+                ],
+              ),
             ),
+            const SizedBox(width: 12.0),
             Column(
               crossAxisAlignment: CrossAxisAlignment.end,
               children: <Widget>[

--- a/flutter_frontend/lib/ui/widgets/conversation/conversations_list_widget.dart
+++ b/flutter_frontend/lib/ui/widgets/conversation/conversations_list_widget.dart
@@ -25,6 +25,7 @@ class ConversationsListWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final theList = ListView.builder(
       shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
       itemCount: conversations.length,
       itemBuilder: (BuildContext context, int index) {
         final Conversation conversation = conversations[index];

--- a/flutter_frontend/lib/ui/widgets/room/room_list_item.dart
+++ b/flutter_frontend/lib/ui/widgets/room/room_list_item.dart
@@ -65,31 +65,35 @@ class _RoomListItemState extends State<RoomListItem> {
         padding: theme.data.padding,
         decoration: theme.data.decoration,
         child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Row(
-              children: <Widget>[
-                const SizedBox(width: 10.0),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Text(
-                      '#${widget.room.name}'.toLowerCase(),
-                      style: theme.data.titleStyle,
+            Expanded(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  const SizedBox(width: 10.0),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          '#${widget.room.name}'.toLowerCase(),
+                          style: theme.data.titleStyle,
+                        ),
+                        const SizedBox(height: 5.0),
+                        Text(
+                          lastMsgString,
+                          style: theme.data.messagePreviewStyle,
+                          overflow: TextOverflow.ellipsis,
+                          maxLines: 1,
+                        ),
+                      ],
                     ),
-                    const SizedBox(height: 5.0),
-                    SizedBox(
-                      width: MediaQuery.of(context).size.width * 0.45,
-                      child: Text(
-                        lastMsgString,
-                        style: theme.data.messagePreviewStyle,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                  ],
-                ),
-              ],
+                  ),
+                ],
+              ),
             ),
+            const SizedBox(width: 12.0),
             Column(
               crossAxisAlignment: CrossAxisAlignment.end,
               children: <Widget>[

--- a/flutter_frontend/lib/ui/widgets/room/room_list_widget.dart
+++ b/flutter_frontend/lib/ui/widgets/room/room_list_widget.dart
@@ -23,6 +23,7 @@ class RoomListWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final theList = ListView.builder(
       shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
       itemCount: rooms.length,
       itemBuilder: (BuildContext context, int index) {
         final Room room = rooms[index];

--- a/flutter_frontend/test/ui/pages/home_page_test.dart
+++ b/flutter_frontend/test/ui/pages/home_page_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libmsgr/libmsgr.dart';
+import 'package:messngr/config/AppNavigation.dart';
+import 'package:messngr/redux/app_state.dart';
+import 'package:messngr/redux/authentication/auth_state.dart';
+import 'package:messngr/redux/team_state.dart';
+import 'package:messngr/redux/ui/ui_state.dart';
+import 'package:messngr/ui/pages/home_page/home_page.dart';
+import 'package:messngr/utils/flutter_redux.dart';
+import 'package:redux/redux.dart';
+
+void main() {
+  late Store<AppState> store;
+
+  setUp(() {
+    final team = Team.raw(
+      id: 'team-1',
+      name: 'Flow',
+      description: 'Test team',
+      creatorUid: 'user-1',
+      createdAt: DateTime(2023, 1, 1),
+      updatedAt: DateTime(2023, 1, 1),
+    );
+
+    final authState = AuthState(
+      kIsLoggedIn: true,
+      currentUser: null,
+      currentProfile: null,
+      currentTeam: team,
+      currentTeamName: team.name,
+      teams: [team],
+      teamAccessToken: 'token',
+      isLoading: false,
+    );
+
+    final teamState = TeamState(
+      selectedTeam: team,
+      rooms: const [],
+      conversations: const [],
+    );
+
+    final appState = AppState(
+      authState: authState,
+      teamState: teamState,
+      currentRoute: AppNavigation.dashboardPath,
+      uiState: UiState(
+        windowPosition: Offset.zero,
+        windowSize: const Size(800, 600),
+      ),
+    );
+
+    store = Store<AppState>(
+      (state, action) => state,
+      initialState: appState,
+    );
+  });
+
+  Future<void> _pumpHomePage(WidgetTester tester, Size size) async {
+    await tester.binding.setSurfaceSize(size);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      StoreProvider<AppState>(
+        store: store,
+        child: const MaterialApp(
+          home: HomePage(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders compact layout under tablet breakpoint',
+      (tester) async {
+    await _pumpHomePage(tester, const Size(640, 900));
+
+    expect(find.byKey(const Key('home_compact_layout')), findsOneWidget);
+    expect(find.byKey(const Key('home_medium_layout')), findsNothing);
+    expect(find.byKey(const Key('home_large_layout')), findsNothing);
+  });
+
+  testWidgets('renders tablet layout when width is medium', (tester) async {
+    await _pumpHomePage(tester, const Size(1024, 900));
+
+    expect(find.byKey(const Key('home_compact_layout')), findsNothing);
+    expect(find.byKey(const Key('home_medium_layout')), findsOneWidget);
+    expect(find.byKey(const Key('home_large_layout')), findsNothing);
+  });
+
+  testWidgets('renders desktop layout at wide breakpoints', (tester) async {
+    await _pumpHomePage(tester, const Size(1400, 900));
+
+    expect(find.byKey(const Key('home_large_layout')), findsOneWidget);
+    expect(find.byKey(const Key('home_large_sidebar')), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- redesign the Flutter home page with responsive compact, tablet, and desktop layouts including a sidebar, inbox panel, and action strip
- make the category selector reusable and adjust room/conversation list widgets for the new layout
- document the responsive breakpoints and add widget coverage for the new layout

## Testing
- flutter test *(fails: `flutter` tool is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea07b51a988322bf2e501b3b84c47b