### PR TITLE
Add multi-tenant IDP context and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Replaced the Telegram/Matrix HTTP clients with queue-driven bridge facades for Telegram, Matrix, IRC, and XMPP plus a shared `ServiceBridge` helper and in-memory queue adapter tests.
 - Introduced a queue behaviour contract to standardise `bridge/<service>/<action>` envelopes with trace IDs for all connectors.
 - Updated bridge strategy, architecture, account linking, and platform research docs to focus on StoneMQ-backed daemons and MTProto-based Telegram support.
+- Implemented a multi-tenant identity provider (IDP) umbrella app with tenant schemas, OIDC/OAuth service-provider support, Guardian-based token issuance, Phoenix session helpers, tests, and documentation (`docs/idp.md`).
 - Added a dedicated `llm_gateway` umbrella-app that unifies communication with OpenAI, Azure OpenAI, Google Vertex and OpenAI-kompatible modeller, including konfigurerbar nøkkeloppløsning for system- og team-nivå og omfattende tester/dokumentasjon.
 - Introduced the `Messngr.AI` context, REST API endpoints for chat completions, summaries and conversation replies, plus controller/views, configuration and tests wired to the shared `llm_gateway` service.
 - Enriched the shared msgr message domain with bubble styling, curated theme palettes, and runtime theme switching helpers for every message variant.

--- a/backend/apps/auth_provider/README.md
+++ b/backend/apps/auth_provider/README.md
@@ -1,4 +1,16 @@
-# MessngrWeb
+# Auth Provider (IDP)
+
+This Phoenix application now hosts the Messngr Identity Provider (IDP).
+It exposes device onboarding, passwordless login and an OAuth 2.0/OpenID
+Connect surface powered by [Boruta](https://github.com/dwyl/boruta).
+
+The IDP is fully multi-tenant aware. Each tenant gets a dedicated session
+configuration and a default identity provider strategy. By default a tenant
+uses the native Messngr flow, but you can also register upstream OpenID
+Connect providers when customers bring their own identity platform—our IDP then
+acts as the service provider.
+
+## Local development
 
 To start your Phoenix server:
 
@@ -6,6 +18,20 @@ To start your Phoenix server:
   * Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+
+## Identity tenants
+
+- Create tenants with `AuthProvider.Idp.create_tenant/1`. A native provider is
+  created automatically, or you can supply an `external_oidc` configuration to
+  make Messngr behave as a service provider against a third-party IDP.
+- `AuthProvider.Idp.issue_tokens/3` issues Guardian-backed JWT tokens scoped to
+  a tenant and handles refresh tokens.
+- `AuthProvider.Idp.Session` centralises Phoenix session management so we can
+  safely store tenant, provider and user metadata for the browser flows.
+- `AuthProvider.Idp.build_service_provider_client/1` turns an upstream OIDC
+  configuration into a ready-to-use `OAuth2.Client` instance.
+
+See `docs/idp.md` for more architectural details and future plans.
 
 Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
 

--- a/backend/apps/auth_provider/lib/auth_provider/idp.ex
+++ b/backend/apps/auth_provider/lib/auth_provider/idp.ex
@@ -1,0 +1,277 @@
+defmodule AuthProvider.Idp do
+  @moduledoc """
+  Umbrella context for the Messngr identity provider (IDP).
+
+  The IDP owns tenant configuration, OAuth/OpenID Connect setup, JWT issuance
+  via Guardian and Phoenix session orchestration. It also prepares Messngr to
+  operate as a service provider (SP) when tenants bring their own upstream IDP.
+  """
+
+  import Ecto.Query
+
+  alias Ecto.Changeset
+  alias Ecto.Multi
+  alias Ecto.UUID
+  alias OAuth2.Client
+
+  alias AuthProvider.Account.User
+  alias AuthProvider.Guardian
+  alias AuthProvider.Idp.IdentityProvider
+  alias AuthProvider.Idp.Session
+  alias AuthProvider.Idp.Tenant
+  alias AuthProvider.Repo
+
+  @refresh_defaults [ttl: {4, :weeks}, token_type: "refresh"]
+
+  @doc false
+  def repo, do: Repo
+
+  ## Tenant management -------------------------------------------------------
+
+  @spec list_tenants() :: [Tenant.t()]
+  def list_tenants, do: Repo.all(Tenant)
+
+  @spec get_tenant!(binary() | String.t()) :: Tenant.t()
+  def get_tenant!(id), do: Repo.get!(Tenant, id)
+
+  @spec fetch_tenant(binary() | String.t()) :: {:ok, Tenant.t()} | :error
+  def fetch_tenant(id) do
+    case Repo.get(Tenant, id) || Repo.get_by(Tenant, slug: Tenant.slugify(id)) do
+      %Tenant{} = tenant -> {:ok, tenant}
+      _ -> :error
+    end
+  end
+
+  @spec get_tenant_by_slug!(String.t()) :: Tenant.t()
+  def get_tenant_by_slug!(slug), do: Repo.get_by!(Tenant, slug: Tenant.slugify(slug))
+
+  @spec change_tenant(Tenant.t(), map()) :: Changeset.t()
+  def change_tenant(%Tenant{} = tenant, attrs \\ %{}), do: Tenant.changeset(tenant, attrs)
+
+  @spec create_tenant(map()) :: {:ok, Tenant.t()} | {:error, Changeset.t()}
+  def create_tenant(attrs \\ %{}) do
+    Multi.new()
+    |> Multi.insert(:tenant, Tenant.changeset(%Tenant{}, attrs))
+    |> Multi.merge(fn %{tenant: tenant} -> ensure_default_provider_multi(tenant, attrs) end)
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{tenant: tenant}} -> {:ok, tenant}
+      {:error, _step, %Changeset{} = changeset, _} -> {:error, changeset}
+    end
+  end
+
+  @spec update_tenant(Tenant.t(), map()) :: {:ok, Tenant.t()} | {:error, Changeset.t()}
+  def update_tenant(%Tenant{} = tenant, attrs) do
+    tenant
+    |> Tenant.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @spec delete_tenant(Tenant.t()) :: {:ok, Tenant.t()} | {:error, Changeset.t()}
+  def delete_tenant(%Tenant{} = tenant) do
+    Repo.delete(tenant)
+  end
+
+  ## Identity providers -----------------------------------------------------
+
+  @spec list_identity_providers(Tenant.t()) :: [IdentityProvider.t()]
+  def list_identity_providers(%Tenant{} = tenant) do
+    tenant
+    |> Ecto.assoc(:identity_providers)
+    |> Repo.all()
+  end
+
+  @spec change_identity_provider(IdentityProvider.t(), map()) :: Changeset.t()
+  def change_identity_provider(%IdentityProvider{} = provider, attrs \\ %{}) do
+    IdentityProvider.changeset(provider, attrs)
+  end
+
+  @spec create_identity_provider(Tenant.t(), map()) :: {:ok, IdentityProvider.t()} | {:error, Changeset.t()}
+  def create_identity_provider(%Tenant{} = tenant, attrs) do
+    attrs = attrs |> normalise_provider_attrs() |> Map.put(:tenant_id, tenant.id)
+
+    Multi.new()
+    |> maybe_clear_existing_default(tenant, attrs)
+    |> Multi.insert(:provider, IdentityProvider.changeset(%IdentityProvider{}, attrs))
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{provider: provider}} -> {:ok, provider}
+      {:error, :provider, %Changeset{} = changeset, _} -> {:error, changeset}
+    end
+  end
+
+  @spec update_identity_provider(IdentityProvider.t(), map()) :: {:ok, IdentityProvider.t()} | {:error, Changeset.t()}
+  def update_identity_provider(%IdentityProvider{} = provider, attrs) do
+    provider
+    |> IdentityProvider.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @spec delete_identity_provider(IdentityProvider.t()) :: {:ok, IdentityProvider.t()} | {:error, Changeset.t()}
+  def delete_identity_provider(%IdentityProvider{is_default: true}), do: {:error, :cannot_delete_default}
+  def delete_identity_provider(%IdentityProvider{} = provider), do: Repo.delete(provider)
+
+  @spec fetch_identity_provider(Tenant.t(), binary() | String.t()) :: {:ok, IdentityProvider.t()} | :error
+  def fetch_identity_provider(%Tenant{} = tenant, id_or_slug) do
+    query = from p in IdentityProvider, where: p.tenant_id == ^tenant.id
+
+    result =
+      case UUID.cast(id_or_slug) do
+        {:ok, uuid} -> Repo.get(query, uuid)
+        :error -> Repo.get_by(query, slug: Tenant.slugify(id_or_slug))
+      end
+
+    case result do
+      %IdentityProvider{} = provider -> {:ok, provider}
+      _ -> :error
+    end
+  end
+
+  @spec fetch_default_identity_provider(Tenant.t()) :: {:ok, IdentityProvider.t()} | :error
+  def fetch_default_identity_provider(%Tenant{} = tenant) do
+    tenant
+    |> list_identity_providers()
+    |> Enum.find(& &1.is_default)
+    |> case do
+      %IdentityProvider{} = provider -> {:ok, provider}
+      _ -> :error
+    end
+  end
+
+  @spec default_identity_provider!(Tenant.t()) :: IdentityProvider.t()
+  def default_identity_provider!(%Tenant{} = tenant) do
+    {:ok, provider} = fetch_default_identity_provider(tenant)
+    provider
+  end
+
+  ## Tokens -----------------------------------------------------------------
+
+  @doc """
+  Issues an access token and refresh token for the user scoped to the tenant.
+  """
+  @spec issue_tokens(Tenant.t(), User.t(), keyword()) ::
+          {:ok, %{access_token: String.t(), refresh_token: String.t(), claims: map()}}
+          | {:error, term()}
+  def issue_tokens(%Tenant{} = tenant, %User{} = user, opts \\ []) do
+    base_claims = Map.put(Map.new(Keyword.get(opts, :claims, %{})), "tenant", tenant.slug)
+
+    with {:ok, token, claims} <- Guardian.encode_and_sign(user, base_claims, Keyword.take(opts, [:permissions])),
+         {:ok, refresh_token, _} <- Guardian.encode_and_sign(user, base_claims, refresh_options(opts)) do
+      {:ok, %{access_token: token, refresh_token: refresh_token, claims: claims}}
+    end
+  end
+
+  @doc """
+  Refreshes an access token in place using Guardian.
+  """
+  @spec refresh_token(String.t()) :: {:ok, term()} | {:error, term()}
+  def refresh_token(token), do: Guardian.refresh(token)
+
+  @doc """
+  Verifies a token and returns the stored claims.
+  """
+  @spec verify_token(String.t()) :: {:ok, map()} | {:error, term()}
+  def verify_token(token), do: Guardian.decode_and_verify(token)
+
+  ## Phoenix session helpers ------------------------------------------------
+
+  @doc """
+  Stores tenant and provider metadata in the Phoenix session.
+  """
+  @spec sign_in(Plug.Conn.t(), Tenant.t(), User.t(), IdentityProvider.t(), keyword()) :: Plug.Conn.t()
+  def sign_in(conn, tenant, user, provider, opts \\ []) do
+    Session.sign_in(conn, tenant, user, provider, opts)
+  end
+
+  @doc """
+  Drops the Phoenix session.
+  """
+  @spec sign_out(Plug.Conn.t()) :: Plug.Conn.t()
+  def sign_out(conn), do: Session.sign_out(conn)
+
+  @doc """
+  Loads tenant/provider/user from the session if available.
+  """
+  @spec fetch_current_session(Plug.Conn.t()) :: {Plug.Conn.t(), {:ok, map()} | :error}
+  def fetch_current_session(conn), do: Session.fetch_current(conn)
+
+  ## Service provider helpers -----------------------------------------------
+
+  @doc """
+  Builds an OAuth2 client for an external OIDC identity provider configuration.
+  Returns `{:error, :unsupported_strategy}` for native providers.
+  """
+  @spec build_service_provider_client(IdentityProvider.t()) :: {:ok, Client.t()} | {:error, term()}
+  def build_service_provider_client(%IdentityProvider{strategy: :external_oidc} = provider) do
+    {:ok,
+     Client.new(
+       strategy: OAuth2.Strategy.AuthCode,
+       client_id: provider.client_id,
+       client_secret: provider.client_secret,
+       site: provider.issuer,
+       authorize_url: provider.authorization_endpoint,
+       token_url: provider.token_endpoint
+     )}
+  end
+
+  def build_service_provider_client(_provider), do: {:error, :unsupported_strategy}
+
+  ## Private ----------------------------------------------------------------
+
+  defp ensure_default_provider_multi(%Tenant{} = tenant, attrs) do
+    strategy =
+      Map.get(attrs, :default_identity_provider) ||
+        Map.get(attrs, "default_identity_provider") || tenant.default_identity_provider
+
+    default_attrs =
+      attrs
+      |> Map.get(:default_identity_provider_config, %{})
+      |> Map.merge(Map.get(attrs, "default_identity_provider_config", %{}))
+      |> normalise_provider_attrs()
+      |> Map.merge(%{
+        name:
+          Map.get(attrs, :default_identity_provider_name) ||
+            Map.get(attrs, "default_identity_provider_name") ||
+            "#{tenant.name} IDP",
+        slug:
+          Map.get(attrs, :default_identity_provider_slug) ||
+            Map.get(attrs, "default_identity_provider_slug") ||
+            to_string(strategy),
+        strategy: strategy,
+        is_default: true
+      })
+      |> Map.put(:tenant_id, tenant.id)
+
+    Multi.new()
+    |> Multi.update_all(:clear_defaults, identity_provider_query(tenant), set: [is_default: false])
+    |> Multi.insert(:default_provider, IdentityProvider.changeset(%IdentityProvider{}, default_attrs))
+  end
+
+  defp maybe_clear_existing_default(multi, %Tenant{} = tenant, attrs) do
+    attrs = normalise_provider_attrs(attrs)
+
+    if truthy?(Map.get(attrs, :is_default) || Map.get(attrs, "is_default")) do
+      Multi.update_all(multi, :unset_default, identity_provider_query(tenant), set: [is_default: false])
+    else
+      multi
+    end
+  end
+
+  defp normalise_provider_attrs(%{} = attrs), do: attrs
+  defp normalise_provider_attrs(value) when is_list(value), do: Enum.into(value, %{})
+  defp normalise_provider_attrs(value), do: value
+
+  defp identity_provider_query(%Tenant{} = tenant) do
+    from p in IdentityProvider, where: p.tenant_id == ^tenant.id and p.is_default == true
+  end
+
+  defp truthy?(value) when value in [true, "true", 1, "1"], do: true
+  defp truthy?(_), do: false
+
+  defp refresh_options(opts) do
+    opts
+    |> Keyword.get(:refresh_options, [])
+    |> Keyword.merge(@refresh_defaults)
+  end
+end
+

--- a/backend/apps/auth_provider/lib/auth_provider/idp/identity_provider.ex
+++ b/backend/apps/auth_provider/lib/auth_provider/idp/identity_provider.ex
@@ -1,0 +1,111 @@
+defmodule AuthProvider.Idp.IdentityProvider do
+  @moduledoc """
+  Schema representing either the built-in IDP or an upstream integration
+  where Messngr acts as the service provider.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias __MODULE__
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @type strategy :: :native | :external_oidc
+
+  schema "idp_identity_providers" do
+    belongs_to :tenant, AuthProvider.Idp.Tenant
+
+    field :name, :string
+    field :slug, :string
+    field :strategy, Ecto.Enum, values: [:native, :external_oidc]
+    field :issuer, :string
+    field :client_id, :string
+    field :client_secret, :string
+    field :authorization_endpoint, :string
+    field :token_endpoint, :string
+    field :userinfo_endpoint, :string
+    field :jwks_uri, :string
+    field :metadata, :map, default: %{}
+    field :is_default, :boolean, default: false
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(%IdentityProvider{} = provider, attrs) when is_map(attrs) do
+    provider
+    |> cast(attrs, [
+      :tenant_id,
+      :name,
+      :slug,
+      :strategy,
+      :issuer,
+      :client_id,
+      :client_secret,
+      :authorization_endpoint,
+      :token_endpoint,
+      :userinfo_endpoint,
+      :jwks_uri,
+      :metadata,
+      :is_default
+    ])
+    |> validate_required([:tenant_id, :name])
+    |> put_default_strategy(attrs)
+    |> maybe_generate_slug()
+    |> validate_strategy_requirements()
+    |> put_default_metadata()
+    |> unique_constraint(:slug, name: :idp_identity_providers_tenant_id_slug_index)
+  end
+
+  defp put_default_strategy(changeset, attrs) do
+    case {get_field(changeset, :strategy), Map.get(attrs, "strategy")} do
+      {nil, nil} -> put_change(changeset, :strategy, :native)
+      {nil, val} when val in ["native", :native] -> put_change(changeset, :strategy, :native)
+      {nil, val} when val in ["external_oidc", :external_oidc] ->
+        put_change(changeset, :strategy, :external_oidc)
+      _ -> changeset
+    end
+  end
+
+  defp maybe_generate_slug(changeset) do
+    cond do
+      slug = get_field(changeset, :slug) -> put_change(changeset, :slug, AuthProvider.Idp.Tenant.slugify(slug))
+      name = get_field(changeset, :name) -> put_change(changeset, :slug, AuthProvider.Idp.Tenant.slugify(name))
+      true -> changeset
+    end
+  end
+
+  defp validate_strategy_requirements(changeset) do
+    case get_field(changeset, :strategy) do
+      :external_oidc ->
+        changeset
+        |> validate_required([
+          :issuer,
+          :client_id,
+          :client_secret,
+          :authorization_endpoint,
+          :token_endpoint
+        ])
+      _ -> changeset
+    end
+  end
+
+  defp put_default_metadata(changeset) do
+    update_change(changeset, :metadata, fn
+      nil -> %{}
+      %{} = metadata -> metadata
+      value when is_map(value) -> value
+      _ -> %{}
+    end)
+  end
+
+  @doc """
+  Returns true if the provider uses an upstream OpenID Connect authority.
+  """
+  @spec external_oidc?(IdentityProvider.t()) :: boolean()
+  def external_oidc?(%IdentityProvider{strategy: :external_oidc}), do: true
+  def external_oidc?(_), do: false
+end
+

--- a/backend/apps/auth_provider/lib/auth_provider/idp/session.ex
+++ b/backend/apps/auth_provider/lib/auth_provider/idp/session.ex
@@ -1,0 +1,78 @@
+defmodule AuthProvider.Idp.Session do
+  @moduledoc """
+  Helpers for managing Phoenix sessions tied to IDP tenants.
+
+  The session layer is responsible for keeping track of the current tenant,
+  the identity provider used to sign-in and the authenticated user id. By
+  centralising the logic here we make it trivial to extend in the future with
+  additional metadata such as MFA state or downstream SP assertions.
+  """
+
+  import Plug.Conn
+
+  alias AuthProvider.Account.User
+  alias AuthProvider.Idp
+  alias AuthProvider.Idp.{IdentityProvider, Tenant}
+
+  @tenant_session_key "idp_tenant_id"
+  @user_session_key "idp_user_id"
+  @provider_session_key "idp_provider_id"
+
+  @doc """
+  Stores tenant, provider and user information in the Phoenix session.
+
+  By default the session is renewed which protects against session fixation
+  attacks. This can be overridden by passing `renew: false` in `opts`.
+  """
+  @spec sign_in(Plug.Conn.t(), Tenant.t(), User.t(), IdentityProvider.t(), keyword()) :: Plug.Conn.t()
+  def sign_in(conn, %Tenant{} = tenant, %User{} = user, %IdentityProvider{} = provider, opts \\ []) do
+    conn
+    |> configure_session(renew: Keyword.get(opts, :renew, true))
+    |> put_session(@tenant_session_key, tenant.id)
+    |> put_session(@provider_session_key, provider.id)
+    |> put_session(@user_session_key, user.id)
+  end
+
+  @doc """
+  Clears the Phoenix session and removes IDP related metadata.
+  """
+  @spec sign_out(Plug.Conn.t()) :: Plug.Conn.t()
+  def sign_out(conn) do
+    conn
+    |> configure_session(drop: true)
+  end
+
+  @doc """
+  Hydrates the currently authenticated session, returning the tenant,
+  provider and user if present.
+  """
+  @spec fetch_current(Plug.Conn.t()) :: {Plug.Conn.t(), {:ok, %{tenant: Tenant.t(), provider: IdentityProvider.t(), user: User.t()}} | :error}
+  def fetch_current(conn) do
+    with tenant_id when not is_nil(tenant_id) <- get_session(conn, @tenant_session_key),
+         user_id when not is_nil(user_id) <- get_session(conn, @user_session_key),
+         {:ok, tenant} <- Idp.fetch_tenant(tenant_id),
+         {:ok, user} <- fetch_user(user_id),
+         {:ok, provider} <- fetch_provider(conn, tenant) do
+      {conn, {:ok, %{tenant: tenant, user: user, provider: provider}}}
+    else
+      _ -> {conn, :error}
+    end
+  end
+
+  defp fetch_user(user_id) do
+    case Idp.repo().get(User, user_id) do
+      %User{} = user -> {:ok, user}
+      _ -> :error
+    end
+  end
+
+  defp fetch_provider(conn, tenant) do
+    provider_id = get_session(conn, @provider_session_key)
+
+    case provider_id && Idp.fetch_identity_provider(tenant, provider_id) do
+      {:ok, provider} -> {:ok, provider}
+      _ -> Idp.fetch_default_identity_provider(tenant)
+    end
+  end
+end
+

--- a/backend/apps/auth_provider/lib/auth_provider/idp/tenant.ex
+++ b/backend/apps/auth_provider/lib/auth_provider/idp/tenant.ex
@@ -1,0 +1,131 @@
+defmodule AuthProvider.Idp.Tenant do
+  @moduledoc """
+  Ecto schema representing an identity tenant.
+
+  A tenant encapsulates branding, default authentication strategy and
+  session settings that are used when issuing IDP tokens or cookies. The
+  schema is deliberately small and extensible through the `metadata` map so
+  we can keep iterating on tenant specific features without running new
+  migrations for every tweak.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias __MODULE__
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @typedoc """
+  Supported default identity provider strategies for a tenant.
+
+  `:native` means we rely on our own IDP stack. `:external_oidc` configures the
+  tenant to authenticate against an upstream OpenID Connect provider where
+  Messngr acts as a service provider.
+  """
+  @type strategy :: :native | :external_oidc
+
+  schema "idp_tenants" do
+    field :name, :string
+    field :slug, :string
+    field :default_locale, :string
+    field :default_identity_provider, Ecto.Enum, values: [:native, :external_oidc]
+    field :session_domain, :string
+    field :session_max_age_seconds, :integer, default: 86_400
+    field :metadata, :map, default: %{}
+
+    has_many :identity_providers, AuthProvider.Idp.IdentityProvider
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(%Tenant{} = tenant, attrs) when is_map(attrs) do
+    tenant
+    |> cast(attrs, [
+      :name,
+      :slug,
+      :default_locale,
+      :default_identity_provider,
+      :session_domain,
+      :session_max_age_seconds,
+      :metadata
+    ])
+    |> validate_required([:name])
+    |> cast_default_identity_provider(attrs)
+    |> maybe_generate_slug()
+    |> validate_length(:slug, min: 2)
+    |> unique_constraint(:slug)
+    |> validate_number(:session_max_age_seconds, greater_than: 0)
+    |> put_default_metadata()
+  end
+
+  defp cast_default_identity_provider(changeset, attrs) do
+    case {get_field(changeset, :default_identity_provider), Map.get(attrs, "default_identity_provider")} do
+      {nil, val} when val in ["native", :native] -> put_change(changeset, :default_identity_provider, :native)
+      {nil, val} when val in ["external_oidc", :external_oidc] ->
+        put_change(changeset, :default_identity_provider, :external_oidc)
+      {nil, nil} ->
+        put_change(changeset, :default_identity_provider, :native)
+      _ ->
+        changeset
+    end
+  end
+
+  defp maybe_generate_slug(changeset) do
+    cond do
+      slug = get_field(changeset, :slug) -> put_change(changeset, :slug, slugify(slug))
+      name = get_field(changeset, :name) -> put_change(changeset, :slug, slugify(name))
+      true -> changeset
+    end
+  end
+
+  defp put_default_metadata(changeset) do
+    update_change(changeset, :metadata, fn
+      nil -> %{}
+      %{} = metadata -> metadata
+      value when is_map(value) -> value
+      _ -> %{}
+    end)
+  end
+
+  @doc """
+  Normalises an arbitrary string into a tenant slug.
+  """
+  @spec slugify(String.t()) :: String.t()
+  def slugify(value) when is_binary(value) do
+    value
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/u, "-")
+    |> String.replace(~r/-+/u, "-")
+    |> String.trim("-")
+  end
+
+  def slugify(value), do: to_string(value) |> slugify()
+
+  @doc """
+  Builds the recommended cookie/session configuration for the tenant.
+  """
+  @spec session_options(Tenant.t(), keyword()) :: keyword()
+  def session_options(%Tenant{} = tenant, overrides \\ []) do
+    [
+      store: :cookie,
+      key: tenant_cookie_key(tenant),
+      signing_salt: "iQMaQJWY",
+      same_site: "Lax",
+      domain: tenant.session_domain,
+      max_age: tenant.session_max_age_seconds
+    ]
+    |> Keyword.merge(overrides)
+  end
+
+  @doc """
+  Default cookie key used for the Phoenix session.
+  """
+  @spec tenant_cookie_key(Tenant.t()) :: String.t()
+  def tenant_cookie_key(%Tenant{slug: slug}) do
+    "_msgr_auth_" <> (slug || "tenant")
+  end
+end
+

--- a/backend/apps/auth_provider/priv/repo/migrations/20241016120000_create_idp_tenants.exs
+++ b/backend/apps/auth_provider/priv/repo/migrations/20241016120000_create_idp_tenants.exs
@@ -1,0 +1,43 @@
+defmodule AuthProvider.Repo.Migrations.CreateIdpTenants do
+  use Ecto.Migration
+
+  def change do
+    create table(:idp_tenants, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string, null: false
+      add :slug, :string, null: false
+      add :default_locale, :string
+      add :default_identity_provider, :string, null: false, default: "native"
+      add :session_domain, :string
+      add :session_max_age_seconds, :integer, null: false, default: 86_400
+      add :metadata, :map, null: false, default: %{}
+
+      timestamps()
+    end
+
+    create unique_index(:idp_tenants, [:slug])
+
+    create table(:idp_identity_providers, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :tenant_id, references(:idp_tenants, type: :binary_id, on_delete: :delete_all), null: false
+      add :name, :string, null: false
+      add :slug, :string, null: false
+      add :strategy, :string, null: false, default: "native"
+      add :issuer, :string
+      add :client_id, :string
+      add :client_secret, :string
+      add :authorization_endpoint, :string
+      add :token_endpoint, :string
+      add :userinfo_endpoint, :string
+      add :jwks_uri, :string
+      add :metadata, :map, null: false, default: %{}
+      add :is_default, :boolean, null: false, default: false
+
+      timestamps()
+    end
+
+    create unique_index(:idp_identity_providers, [:tenant_id, :slug])
+    create unique_index(:idp_identity_providers, [:tenant_id], where: "is_default = true", name: :idp_identity_providers_unique_default)
+  end
+end
+

--- a/backend/apps/auth_provider/test/auth_provider/idp_test.exs
+++ b/backend/apps/auth_provider/test/auth_provider/idp_test.exs
@@ -1,0 +1,136 @@
+defmodule AuthProvider.IdpTest do
+  use AuthProvider.DataCase, async: true
+
+  alias AuthProvider.Account.User
+  alias AuthProvider.Idp
+  alias AuthProvider.Idp.IdentityProvider
+  alias AuthProvider.Idp.Tenant
+
+  describe "tenants" do
+    test "create_tenant/1 provisions a native provider by default" do
+      assert {:ok, %Tenant{} = tenant} = Idp.create_tenant(%{name: "Acme Inc"})
+      assert tenant.slug == "acme-inc"
+      assert tenant.default_identity_provider == :native
+
+      providers = Idp.list_identity_providers(tenant)
+      assert [%IdentityProvider{} = provider] = providers
+      assert provider.is_default
+      assert provider.strategy == :native
+    end
+
+    test "create_tenant/1 supports external default provider configuration" do
+      config = %{
+        "issuer" => "https://id.acme.test",
+        "client_id" => "client",
+        "client_secret" => "secret",
+        "authorization_endpoint" => "https://id.acme.test/authorize",
+        "token_endpoint" => "https://id.acme.test/token",
+        "userinfo_endpoint" => "https://id.acme.test/userinfo",
+        "jwks_uri" => "https://id.acme.test/jwks"
+      }
+
+      attrs = %{
+        "name" => "Beta Corp",
+        "default_identity_provider" => "external_oidc",
+        "default_identity_provider_config" => config,
+        "default_identity_provider_slug" => "beta-oidc"
+      }
+
+      assert {:ok, %Tenant{} = tenant} = Idp.create_tenant(attrs)
+      assert tenant.default_identity_provider == :external_oidc
+
+      assert {:ok, %IdentityProvider{} = provider} = Idp.fetch_default_identity_provider(tenant)
+      assert provider.slug == "beta-oidc"
+      assert provider.strategy == :external_oidc
+      assert provider.issuer == config["issuer"]
+    end
+
+    test "update_tenant/2 validates slug normalisation" do
+      {:ok, tenant} = Idp.create_tenant(%{name: "North", slug: "Custom Slug"})
+
+      {:ok, tenant} = Idp.update_tenant(tenant, %{slug: "Rebranded"})
+      assert tenant.slug == "rebranded"
+    end
+  end
+
+  describe "identity providers" do
+    setup do
+      {:ok, tenant} = Idp.create_tenant(%{name: "Tenant"})
+      %{tenant: tenant}
+    end
+
+    test "create_identity_provider/2 enforces default uniqueness", %{tenant: tenant} do
+      {:ok, %IdentityProvider{} = other} =
+        Idp.create_identity_provider(tenant, %{
+          name: "Upstream",
+          strategy: :external_oidc,
+          issuer: "https://id.upstream.test",
+          client_id: "foo",
+          client_secret: "bar",
+          authorization_endpoint: "https://id.upstream.test/auth",
+          token_endpoint: "https://id.upstream.test/token",
+          is_default: true
+        })
+
+      assert {:ok, default} = Idp.fetch_default_identity_provider(tenant)
+      assert default.id == other.id
+      assert default.is_default
+      assert length(Idp.list_identity_providers(tenant)) == 2
+    end
+
+    test "build_service_provider_client/1 supports external oidc", %{tenant: tenant} do
+      {:ok, provider} =
+        Idp.create_identity_provider(tenant, %{
+          name: "OIDC",
+          strategy: :external_oidc,
+          issuer: "https://issuer.example.com",
+          client_id: "client",
+          client_secret: "secret",
+          authorization_endpoint: "https://issuer.example.com/auth",
+          token_endpoint: "https://issuer.example.com/token",
+          userinfo_endpoint: "https://issuer.example.com/userinfo",
+          jwks_uri: "https://issuer.example.com/jwks"
+        })
+
+      assert {:ok, client} = Idp.build_service_provider_client(provider)
+      assert client.client_id == "client"
+    end
+  end
+
+  describe "tokens and sessions" do
+    setup do
+      {:ok, tenant} = Idp.create_tenant(%{name: "Token Corp"})
+      {:ok, user} = %User{} |> User.changeset(%{email: "user@example.com"}) |> Repo.insert()
+      {:ok, provider} = Idp.fetch_default_identity_provider(tenant)
+
+      conn =
+        Plug.Test.conn(:get, "/")
+        |> Plug.Test.init_test_session(%{})
+      %{tenant: tenant, user: user, provider: provider, conn: conn}
+    end
+
+    test "issue_tokens/3 embeds tenant slug in claims", %{tenant: tenant, user: user} do
+      assert {:ok, %{claims: claims}} = Idp.issue_tokens(tenant, user)
+      assert claims["tenant"] == tenant.slug
+    end
+
+    test "sign_in/4 stores ids in session", %{tenant: tenant, user: user, provider: provider, conn: conn} do
+      conn = Idp.sign_in(conn, tenant, user, provider)
+
+      assert Plug.Conn.get_session(conn, "idp_tenant_id") == tenant.id
+      assert Plug.Conn.get_session(conn, "idp_user_id") == user.id
+      assert Plug.Conn.get_session(conn, "idp_provider_id") == provider.id
+
+      {conn, {:ok, %{tenant: current_tenant, user: current_user, provider: current_provider}}} =
+        Idp.fetch_current_session(conn)
+
+      assert current_tenant.id == tenant.id
+      assert current_user.id == user.id
+      assert current_provider.id == provider.id
+
+      conn = Idp.sign_out(conn)
+      assert Plug.Conn.get_session(conn, "idp_tenant_id") == nil
+    end
+  end
+end
+

--- a/backend/docs/idp.md
+++ b/backend/docs/idp.md
@@ -1,0 +1,69 @@
+# Messngr Identity Provider (IDP)
+
+The `auth_provider` Phoenix app now encapsulates the Messngr identity layer. It
+exposes a REST and OAuth/OIDC interface for clients, manages Guardian JWTs and
+coordinates Phoenix sessions for browser flows.
+
+## Goals
+
+- **Unified auth surface** – the IDP issues all tokens used across Messngr and
+  provides a single source for passwordless login, device registration and
+  OAuth 2.0/OpenID Connect.
+- **Multi-tenant** – companies can be onboarded as tenants. Each tenant carries
+  configuration for session cookies, locales and its preferred identity
+  provider strategy.
+- **Bring-your-own-IDP** – tenants can register external OpenID Connect
+  providers. Messngr will act as the service provider (SP) and exchange tokens
+  with the upstream IDP.
+
+## Architecture overview
+
+```
+┌────────────────────┐        ┌────────────────────┐
+│   Messngr client    │        │   External IDP      │
+│ (web/mobile/daemon) │        │  (tenant provided)  │
+└──────────┬─────────┘        └──────────┬─────────┘
+           │                               ▲
+           │ OAuth/OIDC, device login      │
+           ▼                               │
+┌───────────────────────────────────────────────────┐
+│                  AuthProvider.Idp                  │
+│                                                   │
+│  • Tenants & identity providers (Ecto schemas)     │
+│  • Guardian token issuance & refresh               │
+│  • Phoenix session orchestration                   │
+│  • Service provider helpers (OAuth2 client)        │
+└───────────────────────────────────────────────────┘
+```
+
+The IDP context (`AuthProvider.Idp`) stores tenants in the `idp_tenants` table
+and identity provider definitions in `idp_identity_providers`. Each tenant gets
+exactly one default provider – either `:native` (the built-in passwordless flow)
+or `:external_oidc` for bring-your-own-IDP scenarios.
+
+## Key modules
+
+- `AuthProvider.Idp` – public API for managing tenants, issuing tokens,
+  handling Phoenix sessions and building OAuth2 clients when acting as an SP.
+- `AuthProvider.Idp.Tenant` – schema and helpers for slug generation and session
+  configuration (cookie key, domain, TTL).
+- `AuthProvider.Idp.IdentityProvider` – schema describing both native and
+  external providers, including mandatory fields for OIDC integrations.
+- `AuthProvider.Idp.Session` – utilities to store tenant/provider/user metadata
+  inside the Phoenix session safely.
+
+## Acting as a service provider
+
+When a tenant registers an `external_oidc` provider, we store issuer metadata,
+client credentials and endpoints. `AuthProvider.Idp.build_service_provider_client/1`
+creates a ready-to-use `OAuth2.Client` configured for the Authorization Code
+flow so downstream code can redirect users, exchange authorization codes and
+retrieve userinfo/JWKS data.
+
+## Next steps
+
+- Tenant-specific JWKS rotation and signing keys so each tenant can publish its
+  own metadata.
+- Admin UI for managing tenants and upstream provider credentials.
+- Federation adapters (SAML, SCIM) building on top of the existing structures.
+


### PR DESCRIPTION
## Summary
- add the `AuthProvider.Idp` umbrella context that manages tenants, token issuance, Phoenix sessions, and OAuth2 SP clients
- introduce tenant and identity provider schemas with a migration plus Guardian-backed helpers and unit tests
- document the IDP architecture and usage in the auth provider README and `docs/idp.md`

## Testing
- not run (mix command not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ea661c44508322afd722bb1c5c037d