### PR TITLE
Add themed snackbar UI component and typed snackbar messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Begynt å implementere lokal SQLite-cache for meldinger og kontakter i Flutter-klienten med nye DAO-er, migrasjoner og tester.
 - Added audio message support across the shared msgr domain, Flutter chat model, and parser including waveform metadata handling.
 - Built a MinIO-ready media upload API on the Elixir backend with audio/video attachment workflows, storage configuration, and test coverage.
+- Designed a reusable `MsgrSnackBar` UI component with typed snackbar messages, intent-aware theming, and widget/unit tests.
 - Replaced the Telegram/Matrix HTTP clients with queue-driven bridge facades for Telegram, Matrix, IRC, and XMPP plus a shared `ServiceBridge` helper and in-memory queue adapter tests.
 - Introduced a queue behaviour contract to standardise `bridge/<service>/<action>` envelopes with trace IDs for all connectors.
 - Updated bridge strategy, architecture, account linking, and platform research docs to focus on StoneMQ-backed daemons and MTProto-based Telegram support.

--- a/flutter_frontend/lib/ui/widgets/snackbar/msgr_snackbar.dart
+++ b/flutter_frontend/lib/ui/widgets/snackbar/msgr_snackbar.dart
@@ -1,0 +1,435 @@
+import 'package:flutter/material.dart';
+import 'package:msgr_messages/msgr_messages.dart';
+
+/// Styled snackbar inspired by high-end messengers with intent aware visuals.
+class MsgrSnackBar extends SnackBar {
+  MsgrSnackBar({
+    super.key,
+    required MsgrSnackbarMessage message,
+    MsgrSnackBarThemeData? theme,
+    VoidCallback? onAction,
+  }) : this._(
+          message: message,
+          theme: MsgrSnackBarThemeData.standard().merge(theme),
+          onAction: onAction,
+        );
+
+  MsgrSnackBar._({
+    required MsgrSnackbarMessage message,
+    required MsgrSnackBarThemeData theme,
+    VoidCallback? onAction,
+  }) : super(
+          elevation: 0,
+          padding: EdgeInsets.zero,
+          backgroundColor: Colors.transparent,
+          behavior: SnackBarBehavior.floating,
+          margin: theme.margin,
+          duration: message.duration,
+          content: _MsgrSnackBarContent(
+            message: message,
+            theme: theme,
+            onAction: onAction,
+          ),
+        );
+
+  /// Shows the snackbar using the [ScaffoldMessenger] of the given [context].
+  static ScaffoldFeatureController<SnackBar, SnackBarClosedReason> show(
+    BuildContext context,
+    MsgrSnackbarMessage message, {
+    MsgrSnackBarThemeData? theme,
+    VoidCallback? onAction,
+  }) {
+    return ScaffoldMessenger.of(context).showSnackBar(
+      MsgrSnackBar(
+        message: message,
+        theme: theme,
+        onAction: onAction,
+      ),
+    );
+  }
+}
+
+class _MsgrSnackBarContent extends StatelessWidget {
+  const _MsgrSnackBarContent({
+    required this.message,
+    required this.theme,
+    this.onAction,
+  });
+
+  final MsgrSnackbarMessage message;
+  final MsgrSnackBarThemeData theme;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final intentTheme = theme.resolveIntent(message.intent);
+    final titleStyle = theme.titleStyle ??
+        Theme.of(context).textTheme.titleMedium?.copyWith(
+              color: intentTheme.foregroundColor,
+              fontWeight: FontWeight.w600,
+            ) ??
+        TextStyle(
+          color: intentTheme.foregroundColor,
+          fontWeight: FontWeight.w600,
+          fontSize: 16,
+        );
+    final bodyStyle = theme.descriptionStyle ??
+        Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: intentTheme.foregroundColor.withOpacity(0.9),
+            ) ??
+        TextStyle(
+          color: intentTheme.foregroundColor.withOpacity(0.9),
+          fontSize: 13,
+        );
+    final actionStyle = theme.actionStyle ??
+        Theme.of(context).textTheme.labelLarge?.copyWith(
+              color: intentTheme.actionForegroundColor,
+              fontWeight: FontWeight.w600,
+            ) ??
+        TextStyle(
+          color: intentTheme.actionForegroundColor,
+          fontWeight: FontWeight.w600,
+        );
+
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.surfaceColor,
+        borderRadius: theme.borderRadius,
+        boxShadow: theme.shadows,
+      ),
+      child: ClipRRect(
+        borderRadius: theme.borderRadius,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: intentTheme.backgroundGradient,
+                  borderRadius: theme.borderRadius,
+                ),
+              ),
+            ),
+            Padding(
+              padding: theme.padding,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: intentTheme.iconBackgroundColor,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Icon(
+                      intentTheme.icon,
+                      color: intentTheme.foregroundColor,
+                      size: 22,
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          message.title,
+                          style: titleStyle,
+                        ),
+                        if (message.body != null && message.body!.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Text(
+                              message.body!,
+                              style: bodyStyle,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                  if (message.hasAction)
+                    Padding(
+                      padding: const EdgeInsets.only(left: 12),
+                      child: TextButton(
+                        onPressed: onAction,
+                        style: TextButton.styleFrom(
+                          foregroundColor: intentTheme.actionForegroundColor,
+                        ),
+                        child: Text(
+                          message.actionLabel!,
+                          style: actionStyle,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Theme configuration for [MsgrSnackBar].
+class MsgrSnackBarThemeData {
+  MsgrSnackBarThemeData({
+    required this.margin,
+    required this.padding,
+    required this.borderRadius,
+    required List<BoxShadow> shadows,
+    this.titleStyle,
+    this.descriptionStyle,
+    this.actionStyle,
+    required this.surfaceColor,
+    required Map<MsgrSnackbarIntent, MsgrSnackBarIntentTheme> intents,
+  })  : shadows = List.unmodifiable(shadows),
+        intents = Map.unmodifiable(intents);
+
+  /// Distance between the snackbar and the screen edges.
+  final EdgeInsets margin;
+
+  /// Internal padding surrounding the content.
+  final EdgeInsets padding;
+
+  /// Border radius applied to the snackbar container.
+  final BorderRadius borderRadius;
+
+  /// Shadow definition for the snackbar.
+  final List<BoxShadow> shadows;
+
+  /// Optional override for the title text style.
+  final TextStyle? titleStyle;
+
+  /// Optional override for the body text style.
+  final TextStyle? descriptionStyle;
+
+  /// Optional override for the action button text style.
+  final TextStyle? actionStyle;
+
+  /// Base colour rendered beneath the gradient.
+  final Color surfaceColor;
+
+  /// Mapping between intent and the colours/icons used.
+  final Map<MsgrSnackbarIntent, MsgrSnackBarIntentTheme> intents;
+
+  /// Creates the opinionated default theme used by the snackbars.
+  factory MsgrSnackBarThemeData.standard() {
+    return MsgrSnackBarThemeData(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      borderRadius: const BorderRadius.all(Radius.circular(16)),
+      shadows: const [
+        BoxShadow(
+          color: Color(0x33000000),
+          blurRadius: 24,
+          offset: Offset(0, 16),
+        ),
+      ],
+      surfaceColor: const Color(0xFF111827),
+      intents: const {
+        MsgrSnackbarIntent.success: MsgrSnackBarIntentTheme(
+          icon: Icons.check_circle_rounded,
+          foregroundColor: Colors.white,
+          backgroundGradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            stops: [0.0, 0.55, 1.0],
+            colors: [
+              Color(0xFF166534),
+              Color(0xFF22C55E),
+              Color(0x00111827),
+            ],
+          ),
+        ),
+        MsgrSnackbarIntent.error: MsgrSnackBarIntentTheme(
+          icon: Icons.error_rounded,
+          foregroundColor: Colors.white,
+          backgroundGradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            stops: [0.0, 0.55, 1.0],
+            colors: [
+              Color(0xFF7F1D1D),
+              Color(0xFFEF4444),
+              Color(0x00111827),
+            ],
+          ),
+        ),
+        MsgrSnackbarIntent.warning: MsgrSnackBarIntentTheme(
+          icon: Icons.warning_rounded,
+          foregroundColor: Colors.white,
+          backgroundGradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            stops: [0.0, 0.55, 1.0],
+            colors: [
+              Color(0xFFB45309),
+              Color(0xFFF97316),
+              Color(0x00111827),
+            ],
+          ),
+        ),
+        MsgrSnackbarIntent.info: MsgrSnackBarIntentTheme(
+          icon: Icons.info_rounded,
+          foregroundColor: Colors.white,
+          backgroundGradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            stops: [0.0, 0.55, 1.0],
+            colors: [
+              Color(0xFF1D4ED8),
+              Color(0xFF3B82F6),
+              Color(0x00111827),
+            ],
+          ),
+        ),
+        MsgrSnackbarIntent.help: MsgrSnackBarIntentTheme(
+          icon: Icons.help_rounded,
+          foregroundColor: Colors.white,
+          backgroundGradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            stops: [0.0, 0.55, 1.0],
+            colors: [
+              Color(0xFF6D28D9),
+              Color(0xFFA855F7),
+              Color(0x00111827),
+            ],
+          ),
+        ),
+      },
+    );
+  }
+
+  /// Returns a copy with selectively overridden properties.
+  MsgrSnackBarThemeData copyWith({
+    EdgeInsets? margin,
+    EdgeInsets? padding,
+    BorderRadius? borderRadius,
+    List<BoxShadow>? shadows,
+    TextStyle? titleStyle,
+    TextStyle? descriptionStyle,
+    TextStyle? actionStyle,
+    Color? surfaceColor,
+    Map<MsgrSnackbarIntent, MsgrSnackBarIntentTheme>? intentThemes,
+  }) {
+    return MsgrSnackBarThemeData(
+      margin: margin ?? this.margin,
+      padding: padding ?? this.padding,
+      borderRadius: borderRadius ?? this.borderRadius,
+      shadows: shadows == null ? this.shadows : List.unmodifiable(shadows),
+      titleStyle: titleStyle ?? this.titleStyle,
+      descriptionStyle: descriptionStyle ?? this.descriptionStyle,
+      actionStyle: actionStyle ?? this.actionStyle,
+      surfaceColor: surfaceColor ?? this.surfaceColor,
+      intents: intentThemes == null
+          ? intents
+          : Map.unmodifiable({
+              ...intents,
+              ...intentThemes,
+            }),
+    );
+  }
+
+  /// Combines this theme with [other], letting [other] override the values.
+  MsgrSnackBarThemeData merge(MsgrSnackBarThemeData? other) {
+    if (other == null) {
+      return this;
+    }
+    return copyWith(
+      margin: other.margin,
+      padding: other.padding,
+      borderRadius: other.borderRadius,
+      shadows: other.shadows,
+      titleStyle: other.titleStyle,
+      descriptionStyle: other.descriptionStyle,
+      actionStyle: other.actionStyle,
+      surfaceColor: other.surfaceColor,
+      intentThemes: other.intents,
+    );
+  }
+
+  /// Resolves the theme for the provided [intent].
+  MsgrSnackBarIntentTheme resolveIntent(MsgrSnackbarIntent intent) {
+    return intents[intent] ?? intents[MsgrSnackbarIntent.info]!;
+  }
+}
+
+/// Theme fragment describing iconography and colours for a snackbar intent.
+class MsgrSnackBarIntentTheme {
+  const MsgrSnackBarIntentTheme({
+    required this.icon,
+    required this.foregroundColor,
+    required this.backgroundGradient,
+    this.iconBackgroundColor = const Color(0x33FFFFFF),
+    Color? actionForegroundColor,
+  }) : actionForegroundColor =
+            actionForegroundColor ?? foregroundColor;
+
+  /// Icon rendered inside the intent badge.
+  final IconData icon;
+
+  /// Primary colour used for text and icons.
+  final Color foregroundColor;
+
+  /// Gradient drawn behind the snackbar content.
+  final Gradient backgroundGradient;
+
+  /// Background colour used for the circular icon container.
+  final Color iconBackgroundColor;
+
+  /// Colour used for the action label.
+  final Color actionForegroundColor;
+
+  /// Creates a modified copy of this intent theme.
+  MsgrSnackBarIntentTheme copyWith({
+    IconData? icon,
+    Color? foregroundColor,
+    Gradient? backgroundGradient,
+    Color? iconBackgroundColor,
+    Color? actionForegroundColor,
+  }) {
+    return MsgrSnackBarIntentTheme(
+      icon: icon ?? this.icon,
+      foregroundColor: foregroundColor ?? this.foregroundColor,
+      backgroundGradient: backgroundGradient ?? this.backgroundGradient,
+      iconBackgroundColor: iconBackgroundColor ?? this.iconBackgroundColor,
+      actionForegroundColor: actionForegroundColor ?? this.actionForegroundColor,
+    );
+  }
+}
+
+/// Convenience helpers for showing the snackbar from a [ScaffoldMessenger].
+extension MsgrSnackBarMessenger on ScaffoldMessengerState {
+  ScaffoldFeatureController<SnackBar, SnackBarClosedReason> showMsgrSnackBar(
+    MsgrSnackbarMessage message, {
+    MsgrSnackBarThemeData? theme,
+    VoidCallback? onAction,
+  }) {
+    return showSnackBar(
+      MsgrSnackBar(
+        message: message,
+        theme: theme,
+        onAction: onAction,
+      ),
+    );
+  }
+}
+
+/// Convenience extension on [BuildContext] for the snackbar helper.
+extension MsgrSnackBarContext on BuildContext {
+  ScaffoldFeatureController<SnackBar, SnackBarClosedReason> showMsgrSnackBar(
+    MsgrSnackbarMessage message, {
+    MsgrSnackBarThemeData? theme,
+    VoidCallback? onAction,
+  }) {
+    return ScaffoldMessenger.of(this).showMsgrSnackBar(
+      message,
+      theme: theme,
+      onAction: onAction,
+    );
+  }
+}

--- a/flutter_frontend/packages/msgr_messages/lib/msgr_messages.dart
+++ b/flutter_frontend/packages/msgr_messages/lib/msgr_messages.dart
@@ -13,3 +13,4 @@ export 'src/msgr_image_message.dart';
 export 'src/msgr_video_message.dart';
 export 'src/msgr_location_message.dart';
 export 'src/msgr_audio_message.dart';
+export 'src/msgr_snackbar_message.dart';

--- a/flutter_frontend/packages/msgr_messages/lib/src/msgr_snackbar_message.dart
+++ b/flutter_frontend/packages/msgr_messages/lib/src/msgr_snackbar_message.dart
@@ -1,0 +1,150 @@
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// Describes the semantic intent of a snackbar notification.
+enum MsgrSnackbarIntent {
+  /// Communicates that an operation completed successfully.
+  success,
+
+  /// Indicates that something failed and requires user attention.
+  error,
+
+  /// Highlights information that might need confirmation or awareness.
+  warning,
+
+  /// Shares neutral context, updates or guidance.
+  info,
+
+  /// Presents contextual help or onboarding style hints.
+  help,
+}
+
+/// Immutable model that represents a snackbar notification to be rendered.
+@immutable
+class MsgrSnackbarMessage extends Equatable {
+  /// Creates a snackbar description.
+  const MsgrSnackbarMessage({
+    required this.id,
+    required this.title,
+    this.body,
+    this.intent = MsgrSnackbarIntent.info,
+    Duration? duration,
+    this.actionLabel,
+    Map<String, dynamic>? metadata,
+  })  : duration = duration ?? const Duration(seconds: 4),
+        metadata = metadata == null
+            ? const {}
+            : Map.unmodifiable(Map.of(metadata));
+
+  /// Unique identifier for the snackbar, useful when tracking dismissals.
+  final String id;
+
+  /// Primary heading rendered with emphasis.
+  final String title;
+
+  /// Optional supporting body copy shown under the title.
+  final String? body;
+
+  /// Semantic intent that influences colours and icons in the UI.
+  final MsgrSnackbarIntent intent;
+
+  /// Duration the snackbar should stay visible.
+  final Duration duration;
+
+  /// Optional label rendered for an action button.
+  final String? actionLabel;
+
+  /// Free-form metadata that consumers can leverage for callbacks.
+  final Map<String, dynamic> metadata;
+
+  /// Whether the snackbar exposes an action to the user.
+  bool get hasAction => (actionLabel ?? '').isNotEmpty;
+
+  /// Creates a modified copy of this snackbar message.
+  MsgrSnackbarMessage copyWith({
+    String? id,
+    String? title,
+    String? body,
+    MsgrSnackbarIntent? intent,
+    Duration? duration,
+    String? actionLabel,
+    Map<String, dynamic>? metadata,
+  }) {
+    return MsgrSnackbarMessage(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      body: body ?? this.body,
+      intent: intent ?? this.intent,
+      duration: duration ?? this.duration,
+      actionLabel: actionLabel ?? this.actionLabel,
+      metadata: metadata ?? this.metadata,
+    );
+  }
+
+  /// Serialises this snackbar into a JSON friendly map.
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'title': title,
+      'body': body,
+      'intent': intent.name,
+      'durationMilliseconds': duration.inMilliseconds,
+      'actionLabel': actionLabel,
+      'metadata': metadata,
+    };
+  }
+
+  /// Recreates a snackbar from its serialised representation.
+  factory MsgrSnackbarMessage.fromMap(Map<String, dynamic> map) {
+    return MsgrSnackbarMessage(
+      id: map['id'] as String? ?? '',
+      title: map['title'] as String? ?? '',
+      body: map['body'] as String?,
+      intent: _intentFrom(map['intent']),
+      duration: Duration(
+        milliseconds: (map['durationMilliseconds'] as num?)?.toInt() ??
+            (map['duration_ms'] as num?)?.toInt() ??
+            const Duration(seconds: 4).inMilliseconds,
+      ),
+      actionLabel: map['actionLabel'] as String? ?? map['action_label'] as String?,
+      metadata: _readMetadata(map['metadata']),
+    );
+  }
+
+  static MsgrSnackbarIntent _intentFrom(dynamic value) {
+    if (value is MsgrSnackbarIntent) {
+      return value;
+    }
+    final name = value?.toString().toLowerCase();
+    switch (name) {
+      case 'success':
+        return MsgrSnackbarIntent.success;
+      case 'error':
+        return MsgrSnackbarIntent.error;
+      case 'warning':
+        return MsgrSnackbarIntent.warning;
+      case 'help':
+        return MsgrSnackbarIntent.help;
+      default:
+        return MsgrSnackbarIntent.info;
+    }
+  }
+
+  static Map<String, dynamic> _readMetadata(dynamic value) {
+    if (value is Map<String, dynamic>) {
+      return Map.unmodifiable(Map.of(value));
+    }
+    return const {};
+  }
+
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        body,
+        intent,
+        duration,
+        actionLabel,
+        metadata,
+      ];
+}

--- a/flutter_frontend/packages/msgr_messages/test/msgr_snackbar_message_test.dart
+++ b/flutter_frontend/packages/msgr_messages/test/msgr_snackbar_message_test.dart
@@ -1,0 +1,85 @@
+import 'package:msgr_messages/msgr_messages.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MsgrSnackbarMessage', () {
+    test('supports value equality', () {
+      const messageA = MsgrSnackbarMessage(
+        id: 'a',
+        title: 'Saved',
+        intent: MsgrSnackbarIntent.success,
+      );
+      const messageB = MsgrSnackbarMessage(
+        id: 'a',
+        title: 'Saved',
+        intent: MsgrSnackbarIntent.success,
+      );
+
+      expect(messageA, equals(messageB));
+    });
+
+    test('copyWith overrides provided fields', () {
+      const base = MsgrSnackbarMessage(
+        id: '1',
+        title: 'Initial',
+        intent: MsgrSnackbarIntent.info,
+        body: 'Hello',
+        actionLabel: 'Undo',
+      );
+
+      final copy = base.copyWith(
+        id: '2',
+        title: 'Updated',
+        intent: MsgrSnackbarIntent.error,
+        duration: const Duration(seconds: 10),
+        body: 'World',
+        actionLabel: 'Retry',
+        metadata: const {'traceId': 'abc'},
+      );
+
+      expect(copy.id, '2');
+      expect(copy.title, 'Updated');
+      expect(copy.intent, MsgrSnackbarIntent.error);
+      expect(copy.duration, const Duration(seconds: 10));
+      expect(copy.body, 'World');
+      expect(copy.actionLabel, 'Retry');
+      expect(copy.metadata, {'traceId': 'abc'});
+      expect(copy.hasAction, isTrue);
+    });
+
+    test('toMap serialises intent and duration', () {
+      const message = MsgrSnackbarMessage(
+        id: '3',
+        title: 'Warning',
+        intent: MsgrSnackbarIntent.warning,
+        duration: Duration(milliseconds: 2500),
+        metadata: {'reason': 'quota'},
+      );
+
+      final map = message.toMap();
+
+      expect(map['intent'], 'warning');
+      expect(map['durationMilliseconds'], 2500);
+      expect(map['metadata'], {'reason': 'quota'});
+    });
+
+    test('fromMap parses unknown values gracefully', () {
+      final message = MsgrSnackbarMessage.fromMap({
+        'id': '4',
+        'title': 'Fallback',
+        'body': 'Body',
+        'intent': 'unknown',
+        'durationMilliseconds': 1500,
+        'action_label': 'Dismiss',
+        'metadata': {'source': 'test'},
+      });
+
+      expect(message.intent, MsgrSnackbarIntent.info);
+      expect(message.duration, const Duration(milliseconds: 1500));
+      expect(message.actionLabel, 'Dismiss');
+      expect(message.body, 'Body');
+      expect(message.metadata, {'source': 'test'});
+      expect(message.hasAction, isTrue);
+    });
+  });
+}

--- a/flutter_frontend/test/ui/widgets/snackbar/msgr_snackbar_test.dart
+++ b/flutter_frontend/test/ui/widgets/snackbar/msgr_snackbar_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:messngr/ui/widgets/snackbar/msgr_snackbar.dart';
+import 'package:msgr_messages/msgr_messages.dart';
+
+void main() {
+  group('MsgrSnackBar', () {
+    testWidgets('renders title, body and action with default theme', (tester) async {
+      const message = MsgrSnackbarMessage(
+        id: 'success',
+        title: 'Alt lagret!',
+        body: 'Vi synkroniserte meldingen med alle enheter.',
+        intent: MsgrSnackbarIntent.success,
+        actionLabel: 'Angre',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return Center(
+                  child: ElevatedButton(
+                    onPressed: () {
+                      context.showMsgrSnackBar(
+                        message,
+                        onAction: () {},
+                      );
+                    },
+                    child: const Text('Vis snackbar'),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Vis snackbar'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.text('Alt lagret!'), findsOneWidget);
+      expect(
+        find.text('Vi synkroniserte meldingen med alle enheter.'),
+        findsOneWidget,
+      );
+      expect(find.text('Angre'), findsOneWidget);
+      expect(find.byIcon(Icons.check_circle_rounded), findsOneWidget);
+    });
+
+    testWidgets('applies theme overrides when provided', (tester) async {
+      final baseTheme = MsgrSnackBarThemeData.standard();
+      final customTheme = baseTheme.copyWith(
+        margin: const EdgeInsets.all(24),
+        intentThemes: {
+          MsgrSnackbarIntent.error: baseTheme
+              .resolveIntent(MsgrSnackbarIntent.error)
+              .copyWith(icon: Icons.close_rounded),
+        },
+      );
+
+      const message = MsgrSnackbarMessage(
+        id: 'error',
+        title: 'Kunne ikke lagre',
+        intent: MsgrSnackbarIntent.error,
+        actionLabel: 'Prøv igjen',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return Center(
+                  child: ElevatedButton(
+                    onPressed: () {
+                      context.showMsgrSnackBar(
+                        message,
+                        theme: customTheme,
+                        onAction: () {},
+                      );
+                    },
+                    child: const Text('Trigger'),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      final snackBarFinder = find.byWidgetPredicate(
+        (widget) => widget is SnackBar && widget.margin == const EdgeInsets.all(24),
+      );
+      expect(snackBarFinder, findsOneWidget);
+      expect(find.byIcon(Icons.close_rounded), findsOneWidget);
+      expect(find.text('Prøv igjen'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a typed `MsgrSnackbarMessage` intent model and export it from the shared message package
- implement a themed `MsgrSnackBar` widget with intent-aware styling and helper extensions
- cover the new snackbar model and widget with unit/widget tests and document the addition in the changelog

## Testing
- `flutter test` *(fails: `flutter` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea6c6a28988322aadc5372f3a3ef15