### PR TITLE
Add chat pagination and watcher support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Implementerte cursor-baserte historikk-APIer for meldinger og samtaler med
+  PubSub-backlog (`message:sync`) og watcher-strømmer (`conversation:watch`/`unwatch`).
 - Designet et modulært Flutter chat-UI-kit (kanalliste, trådvisning, reaksjoner, presence, tilkoblingsbanner) og integrerte det i `ChatPage` og en ny `ChannelListPage`-demo.
 - Utvidet `ChatComposer` med emoji-velger, slash-kommandoer, filvedlegg, simulert taleopptak og forbedret utkast-/feilhåndtering samt nye widgettester.
 - Implementerte hurtigbuffer for samtaler og meldinger med Hive/Sembast, offline statusbanner og integrasjonstester for fallback i `ChatViewModel`.

--- a/backend/apps/msgr/lib/msgr.ex
+++ b/backend/apps/msgr/lib/msgr.ex
@@ -33,7 +33,12 @@ defmodule Messngr do
   end
   defdelegate send_message(conversation_id, profile_id, attrs), to: Chat
   def list_messages(conversation_id, opts \\ []), do: Chat.list_messages(conversation_id, opts)
+  def list_conversations(profile_id, opts \\ []), do: Chat.list_conversations(profile_id, opts)
   defdelegate ensure_membership(conversation_id, profile_id), to: Chat
+  defdelegate watch_conversation(conversation_id, profile_id), to: Chat
+  defdelegate unwatch_conversation(conversation_id, profile_id), to: Chat
+  defdelegate list_watchers(conversation_id), to: Chat
+  defdelegate broadcast_backlog(conversation_id, page), to: Chat
   defdelegate create_media_upload(conversation_id, profile_id, attrs), to: Media, as: :create_upload
 
   # AI

--- a/backend/apps/msgr/lib/msgr/ai.ex
+++ b/backend/apps/msgr/lib/msgr/ai.ex
@@ -107,7 +107,8 @@ defmodule Messngr.AI do
   def conversation_reply(team_id, conversation_id, %Profile{} = profile, opts \\ []) do
     history_limit = Keyword.get(opts, :history_limit, 20)
 
-    history = Chat.list_messages(conversation_id, limit: history_limit)
+    history_page = Chat.list_messages(conversation_id, limit: history_limit)
+    history = history_page.entries
 
     system_prompt =
       opts

--- a/backend/apps/msgr/lib/msgr/chat/conversation.ex
+++ b/backend/apps/msgr/lib/msgr/chat/conversation.ex
@@ -18,6 +18,8 @@ defmodule Messngr.Chat.Conversation do
       default: nil
 
     field :visibility, Ecto.Enum, values: [:private, :team], default: :private
+    field :unread_count, :integer, virtual: true, default: 0
+    field :last_message, :map, virtual: true
 
     has_many :participants, Messngr.Chat.Participant
     has_many :messages, Messngr.Chat.Message

--- a/backend/apps/msgr_web/lib/msgr_web/controllers/conversation_json.ex
+++ b/backend/apps/msgr_web/lib/msgr_web/controllers/conversation_json.ex
@@ -1,9 +1,18 @@
 defmodule MessngrWeb.ConversationJSON do
-  alias Messngr.Chat.Conversation
+  alias Messngr.Chat.{Conversation, Message}
   alias Messngr.Accounts.Profile
+  alias MessngrWeb.MessageJSON
 
   def show(%{conversation: conversation}) do
     %{data: conversation(conversation)}
+  end
+
+  def index(%{page: %{entries: entries, meta: meta}}) do
+    %{data: Enum.map(entries, &conversation/1), meta: encode_meta(meta)}
+  end
+
+  def watchers(%{payload: payload}) do
+    %{data: %{watchers: payload.watchers, count: payload.count}}
   end
 
   defp conversation(%Conversation{} = conversation) do
@@ -13,7 +22,9 @@ defmodule MessngrWeb.ConversationJSON do
       topic: conversation.topic,
       structure_type: conversation.structure_type,
       visibility: conversation.visibility,
-      participants: Enum.map(conversation.participants, &participant/1)
+      participants: Enum.map(conversation.participants, &participant/1),
+      unread_count: conversation.unread_count || 0,
+      last_message: encode_last_message(conversation.last_message)
     }
   end
 
@@ -28,6 +39,25 @@ defmodule MessngrWeb.ConversationJSON do
       },
       role: participant.role,
       last_read_at: participant.last_read_at
+    }
+  end
+
+  defp encode_last_message(%Message{} = message) do
+    MessageJSON.show(%{message: message})[:data]
+  end
+
+  defp encode_last_message(_), do: nil
+
+  defp encode_meta(nil), do: %{start_cursor: nil, end_cursor: nil, has_more: %{before: false, after: false}}
+
+  defp encode_meta(meta) when is_map(meta) do
+    %{
+      start_cursor: Map.get(meta, :start_cursor),
+      end_cursor: Map.get(meta, :end_cursor),
+      has_more: %{
+        before: get_in(meta, [:has_more, :before]) || false,
+        after: get_in(meta, [:has_more, :after]) || false
+      }
     }
   end
 end

--- a/backend/apps/msgr_web/lib/msgr_web/controllers/message_controller.ex
+++ b/backend/apps/msgr_web/lib/msgr_web/controllers/message_controller.ex
@@ -9,10 +9,9 @@ defmodule MessngrWeb.MessageController do
     current_profile = conn.assigns.current_profile
 
     with _participant <- Messngr.ensure_membership(conversation_id, current_profile.id) do
-      messages =
-        Messngr.list_messages(conversation_id, build_list_opts(params))
+      page = Messngr.list_messages(conversation_id, build_list_opts(params))
 
-      render(conn, :index, messages: messages)
+      render(conn, :index, page: page)
     end
   rescue
     Ecto.NoResultsError -> {:error, :forbidden}
@@ -39,6 +38,8 @@ defmodule MessngrWeb.MessageController do
     []
     |> maybe_put(:limit, params["limit"])
     |> maybe_put(:before_id, params["before_id"])
+    |> maybe_put(:after_id, params["after_id"])
+    |> maybe_put(:around_id, params["around_id"])
   end
 
   defp maybe_put(opts, _key, nil), do: opts
@@ -50,4 +51,6 @@ defmodule MessngrWeb.MessageController do
   end
 
   defp maybe_put(opts, :before_id, value), do: Keyword.put(opts, :before_id, value)
+  defp maybe_put(opts, :after_id, value), do: Keyword.put(opts, :after_id, value)
+  defp maybe_put(opts, :around_id, value), do: Keyword.put(opts, :around_id, value)
 end

--- a/backend/apps/msgr_web/lib/msgr_web/controllers/message_json.ex
+++ b/backend/apps/msgr_web/lib/msgr_web/controllers/message_json.ex
@@ -2,12 +2,25 @@ defmodule MessngrWeb.MessageJSON do
   alias Messngr.Chat.Message
   alias Messngr.Accounts.Profile
 
-  def index(%{messages: messages}) do
-    %{data: Enum.map(messages, &message/1)}
+  def index(%{page: %{entries: entries, meta: meta}}) do
+    %{data: Enum.map(entries, &message/1), meta: encode_meta(meta)}
   end
 
   def show(%{message: message}) do
     %{data: message(message)}
+  end
+
+  defp encode_meta(nil), do: %{start_cursor: nil, end_cursor: nil, has_more: %{before: false, after: false}}
+
+  defp encode_meta(meta) when is_map(meta) do
+    %{
+      start_cursor: Map.get(meta, :start_cursor),
+      end_cursor: Map.get(meta, :end_cursor),
+      has_more: %{
+        before: get_in(meta, [:has_more, :before]) || false,
+        after: get_in(meta, [:has_more, :after]) || false
+      }
+    }
   end
 
   defp message(%Message{} = message) do

--- a/backend/apps/msgr_web/lib/msgr_web/router.ex
+++ b/backend/apps/msgr_web/lib/msgr_web/router.ex
@@ -21,10 +21,14 @@ defmodule MessngrWeb.Router do
   scope "/api", MessngrWeb do
     pipe_through [:api, :actor]
 
+    get "/conversations", ConversationController, :index
     post "/conversations", ConversationController, :create
     post "/conversations/:id/uploads", MediaUploadController, :create
     get "/conversations/:id/messages", MessageController, :index
     post "/conversations/:id/messages", MessageController, :create
+    post "/conversations/:id/watch", ConversationController, :watch
+    delete "/conversations/:id/watch", ConversationController, :unwatch
+    get "/conversations/:id/watchers", ConversationController, :watchers
 
     resources "/families", FamilyController, only: [:index, :create, :show] do
       resources "/events", FamilyEventController, only: [:index, :create, :show, :update, :delete]

--- a/backend/apps/msgr_web/test/msgr_web/controllers/conversation_controller_test.exs
+++ b/backend/apps/msgr_web/test/msgr_web/controllers/conversation_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule MessngrWeb.ConversationControllerTest do
   use MessngrWeb.ConnCase, async: true
 
-  alias Messngr.Accounts
+  alias Messngr.{Accounts, Chat}
 
   setup %{conn: conn} do
     {:ok, current_account} = Accounts.create_account(%{"display_name" => "Kari"})
@@ -28,6 +28,41 @@ defmodule MessngrWeb.ConversationControllerTest do
     assert %{"data" => %{"id" => id, "participants" => participants}} = json_response(conn, 200)
     assert is_binary(id)
     assert length(participants) == 2
+  end
+
+  test "lists conversations with metadata", %{conn: conn, target_profile: target_profile, current_profile: profile} do
+    {:ok, conversation} = Chat.ensure_direct_conversation(profile.id, target_profile.id)
+    {:ok, _} = Chat.send_message(conversation.id, profile.id, %{"body" => "Hei"})
+
+    conn = get(conn, ~p"/api/conversations")
+
+    assert %{
+             "data" => [
+               %{
+                 "id" => ^conversation.id,
+                 "unread_count" => 1,
+                 "last_message" => %{"body" => "Hei"}
+               }
+             ],
+             "meta" => %{"has_more" => %{"after" => false, "before" => false}}
+           } = json_response(conn, 200)
+  end
+
+  test "watch endpoints manage watchers", %{conn: conn, target_profile: target_profile, current_profile: profile} do
+    {:ok, conversation} = Chat.ensure_direct_conversation(profile.id, target_profile.id)
+
+    watch_conn = post(conn, ~p"/api/conversations/#{conversation.id}/watch")
+
+    assert %{"data" => %{"count" => 1, "watchers" => [%{"id" => ^profile.id}]}} =
+             json_response(watch_conn, 200)
+
+    watchers_conn = get(conn, ~p"/api/conversations/#{conversation.id}/watchers")
+
+    assert %{"data" => %{"count" => 1}} = json_response(watchers_conn, 200)
+
+    unwatch_conn = delete(conn, ~p"/api/conversations/#{conversation.id}/watch")
+
+    assert %{"data" => %{"count" => 0}} = json_response(unwatch_conn, 200)
   end
 
   test "missing header returns unauthorized", %{target_profile: target_profile} do

--- a/backend/apps/msgr_web/test/msgr_web/controllers/message_controller_test.exs
+++ b/backend/apps/msgr_web/test/msgr_web/controllers/message_controller_test.exs
@@ -30,8 +30,16 @@ defmodule MessngrWeb.MessageControllerTest do
 
     conn = get(conn, ~p"/api/conversations/#{conversation.id}/messages")
 
-    assert %{"data" => [%{"body" => "Hei", "type" => "text", "payload" => %{}}]} =
-             json_response(conn, 200)
+    assert %{
+             "data" => [
+               %{"body" => "Hei", "type" => "text", "payload" => %{}, "id" => message_id}
+             ],
+             "meta" => %{
+               "start_cursor" => ^message_id,
+               "end_cursor" => ^message_id,
+               "has_more" => %{"before" => false, "after" => false}
+             }
+           } = json_response(conn, 200)
   end
 
   test "creates message", %{conn: conn, conversation: conversation} do

--- a/docs/bridge_architecture.md
+++ b/docs/bridge_architecture.md
@@ -19,6 +19,12 @@
    - Workers trigger periodic sync actions (`request_history`, `refresh_roster`) over the queue.
    - Daemons stream results and update tokens; Elixir writes checkpoints and notifies subscribers.
 
+## Conversation History Streaming
+- Clients request historical windows by pushing `message:sync` on the Phoenix conversation channel.
+- The backend serves cursor-based pages (before/after/around IDs) and rebroadcasts the backlog via PubSub so every watcher receives the same slice.
+- REST controllers expose the same pagination contract, including `unread_count`, `last_message`, and watcher counts per conversation.
+- `conversation:watch` / `conversation:unwatch` maintain lightweight ETS-backed presence lists that surface active viewers to all subscribers.
+
 ## Security Layers
 - Per-daemon containers with AppArmor/seccomp profiles to contain native libraries and reverse-engineered code.
 - Mutual TLS (or Noise handshakes) between daemons and StoneMQ plus signed envelopes verified by the Elixir core.


### PR DESCRIPTION
## Summary
- implement cursor-based pagination helpers for chat, expose unread counts and last message metadata, and add watcher tracking
- return pagination metadata from the REST and channel APIs, including new message:sync and watch/unwatch events
- update documentation and tests to cover backlog broadcasts and watcher flows

## Testing
- mix test *(fails: mix not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea7a4d91648322888f2d7a5ee46920