### PR TITLE
Add account device schema and auth registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+- Added account device management with migrations, CRUD helpers, Noise key
+  attestation storage and auth flow integration so OTP/OIDC logins register
+  and activate devices, including ExUnit coverage.
 - Documented Noise handshake expectations with new server-key endpoint contract, configured backend runtime to load static Noise keys from env/Secrets Manager, added rotation mix task with tests, and updated README guidance.
 - Added a feature toggle and dedicated port configuration for the Noise transport so static keys only load when explicitly enabled.
 - Utvidet mediasystemet med nye skjema-felter (dimensjoner, SHA-256, retention),

--- a/backend/apps/msgr/lib/msgr.ex
+++ b/backend/apps/msgr/lib/msgr.ex
@@ -13,6 +13,13 @@ defmodule Messngr do
   defdelegate create_profile(attrs), to: Accounts
   defdelegate list_profiles(account_id), to: Accounts
   defdelegate get_profile!(id), to: Accounts
+  defdelegate list_devices(account_id), to: Accounts
+  defdelegate get_device!(id), to: Accounts
+  defdelegate create_device(attrs), to: Accounts
+  defdelegate update_device(device, attrs), to: Accounts
+  defdelegate delete_device(device), to: Accounts
+  defdelegate activate_device(device), to: Accounts
+  defdelegate deactivate_device(device), to: Accounts
 
   def import_contacts(account_id, contacts_attrs, opts \\ []) do
     Accounts.import_contacts(account_id, contacts_attrs, opts)

--- a/backend/apps/msgr/lib/msgr/accounts/account.ex
+++ b/backend/apps/msgr/lib/msgr/accounts/account.ex
@@ -20,6 +20,7 @@ defmodule Messngr.Accounts.Account do
     field :time_zone, :string, default: "Europe/Oslo"
 
     has_many :profiles, Messngr.Accounts.Profile
+    has_many :devices, Messngr.Accounts.Device
 
     timestamps(type: :utc_datetime)
   end

--- a/backend/apps/msgr/lib/msgr/accounts/device.ex
+++ b/backend/apps/msgr/lib/msgr/accounts/device.ex
@@ -1,0 +1,61 @@
+defmodule Messngr.Accounts.Device do
+  @moduledoc """
+  Represents a physical or virtual client that authenticates via static Noise keys
+  and is associated with an account/profile.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "account_devices" do
+    field :device_public_key, :string
+    field :attesters, {:array, :map}, default: []
+    field :last_handshake_at, :utc_datetime
+    field :enabled, :boolean, default: true
+
+    belongs_to :account, Messngr.Accounts.Account
+    belongs_to :profile, Messngr.Accounts.Profile
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(device, attrs) do
+    device
+    |> cast(attrs, [
+      :account_id,
+      :profile_id,
+      :device_public_key,
+      :attesters,
+      :last_handshake_at,
+      :enabled
+    ])
+    |> validate_required([:account_id, :device_public_key])
+    |> validate_length(:device_public_key, min: 8)
+    |> normalize_attesters()
+    |> unique_constraint(:device_public_key,
+      name: :account_devices_account_id_device_public_key_index
+    )
+    |> foreign_key_constraint(:account_id)
+    |> foreign_key_constraint(:profile_id)
+  end
+
+  defp normalize_attesters(changeset) do
+    update_change(changeset, :attesters, fn value ->
+      value
+      |> case do
+        nil -> []
+        list when is_list(list) -> list
+        other -> [other]
+      end
+      |> Enum.map(fn
+        %{} = map -> map
+        value -> %{value: to_string(value)}
+      end)
+    end)
+  end
+end

--- a/backend/apps/msgr/lib/msgr/accounts/profile.ex
+++ b/backend/apps/msgr/lib/msgr/accounts/profile.ex
@@ -20,6 +20,7 @@ defmodule Messngr.Accounts.Profile do
     field :security_policy, :map, default: %{"requires_pin" => false}
 
     belongs_to :account, Messngr.Accounts.Account
+    has_many :devices, Messngr.Accounts.Device
 
     timestamps(type: :utc_datetime)
   end

--- a/backend/apps/msgr/priv/repo/migrations/20241004132000_create_account_devices.exs
+++ b/backend/apps/msgr/priv/repo/migrations/20241004132000_create_account_devices.exs
@@ -1,0 +1,24 @@
+defmodule Messngr.Repo.Migrations.CreateAccountDevices do
+  use Ecto.Migration
+
+  def change do
+    create table(:account_devices, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :account_id, references(:accounts, type: :binary_id, on_delete: :delete_all), null: false
+      add :profile_id, references(:profiles, type: :binary_id, on_delete: :nilify_all)
+      add :device_public_key, :string, null: false
+      add :attesters, {:array, :map}, default: [], null: false
+      add :last_handshake_at, :utc_datetime
+      add :enabled, :boolean, default: true, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:account_devices, [:account_id])
+    create index(:account_devices, [:profile_id])
+
+    create unique_index(:account_devices, [:account_id, :device_public_key],
+             name: :account_devices_account_id_device_public_key_index
+           )
+  end
+end

--- a/backend/apps/msgr/test/messngr/accounts/device_test.exs
+++ b/backend/apps/msgr/test/messngr/accounts/device_test.exs
@@ -1,0 +1,98 @@
+defmodule Messngr.Accounts.DeviceTest do
+  use Messngr.DataCase
+
+  alias Messngr.Accounts
+
+  describe "devices" do
+    setup do
+      {:ok, account} = Accounts.create_account(%{"display_name" => "Device Owner", "email" => "owner@example.com"})
+      profile = List.first(account.profiles)
+
+      {:ok, account: account, profile: profile}
+    end
+
+    test "create_device/1 persists Noise key and attesters", %{account: account, profile: profile} do
+      {:ok, device} =
+        Accounts.create_device(%{
+          account_id: account.id,
+          profile_id: profile.id,
+          device_public_key: "noise1-abcdefghijk",
+          attesters: [%{id: "server", signature: "abc"}]
+        })
+
+      assert device.account_id == account.id
+      assert device.profile_id == profile.id
+      assert device.enabled
+      assert [%{"id" => "server", "signature" => "abc"}] =
+               Enum.map(device.attesters, &normalize_keys/1)
+
+      assert [device.id] == Enum.map(Accounts.list_devices(account.id), & &1.id)
+    end
+
+    test "activate_device/1 and deactivate_device/1 toggle enabled flag", %{account: account} do
+      {:ok, device} =
+        Accounts.create_device(%{
+          account_id: account.id,
+          device_public_key: "noise2-abcdefghijk"
+        })
+
+      {:ok, disabled} = Accounts.deactivate_device(device)
+      refute disabled.enabled
+
+      {:ok, reenabled} = Accounts.activate_device(disabled)
+      assert reenabled.enabled
+    end
+
+    test "attach_device_for_identity/2 upserts and preloads account devices", _context do
+      {:ok, identity} =
+        Accounts.ensure_identity(%{
+          kind: :email,
+          value: "device-user@example.com",
+          display_name: "Device User"
+        })
+
+      {:ok, %{identity: updated_identity, device: device}} =
+        Accounts.attach_device_for_identity(identity, %{
+          device_public_key: "noise-device-123",
+          attesters: [%{id: "server"}]
+        })
+
+      assert device.device_public_key == "noise-device-123"
+      assert device.account_id == updated_identity.account_id
+      assert device.profile_id != nil
+      assert Enum.any?(updated_identity.account.devices, &(&1.id == device.id))
+
+      last_seen = device.last_handshake_at || DateTime.utc_now()
+
+      {:ok, %{device: same_device}} =
+        Accounts.attach_device_for_identity(updated_identity, %{
+          device_public_key: "noise-device-123",
+          last_handshake_at: DateTime.add(last_seen, 5, :second)
+        })
+
+      assert DateTime.compare(same_device.last_handshake_at, device.last_handshake_at) == :gt
+    end
+
+    test "create_device/1 enforces unique Noise key per account", %{account: account} do
+      {:ok, _device} =
+        Accounts.create_device(%{
+          account_id: account.id,
+          device_public_key: "noise-unique-1"
+        })
+
+      assert {:error, changeset} =
+               Accounts.create_device(%{
+                 account_id: account.id,
+                 device_public_key: "noise-unique-1"
+               })
+
+      assert %{device_public_key: ["has already been taken"]} = errors_on(changeset)
+    end
+  end
+
+  defp normalize_keys(map) when is_map(map) do
+    map
+    |> Enum.map(fn {k, v} -> {to_string(k), v} end)
+    |> Map.new()
+  end
+end

--- a/backend/apps/msgr/test/messngr/auth/device_flow_test.exs
+++ b/backend/apps/msgr/test/messngr/auth/device_flow_test.exs
@@ -1,0 +1,65 @@
+defmodule Messngr.Auth.DeviceFlowTest do
+  use Messngr.DataCase
+
+  describe "OTP device registration" do
+    test "verify_auth_challenge/3 upserts device using issued_for" do
+      {:ok, challenge, code} =
+        Messngr.start_auth_challenge(%{
+          "channel" => "email",
+          "identifier" => "otp-device@example.com",
+          "device_id" => "noise-otp-123"
+        })
+
+      {:ok, %{account: account, identity: identity}} =
+        Messngr.verify_auth_challenge(challenge.id, code, %{"display_name" => "OTP Device"})
+
+      device = Enum.find(account.devices, &(&1.device_public_key == "noise-otp-123"))
+      assert device
+      assert device.enabled
+      assert device.last_handshake_at
+      assert identity.account.devices |> Enum.any?(&(&1.id == device.id))
+
+      {:ok, challenge2, code2} =
+        Messngr.start_auth_challenge(%{
+          "channel" => "email",
+          "identifier" => "otp-device@example.com",
+          "device_id" => "noise-otp-123"
+        })
+
+      first_handshake = device.last_handshake_at
+
+      {:ok, %{account: account2}} =
+        Messngr.verify_auth_challenge(challenge2.id, code2, %{})
+
+      device2 = Enum.find(account2.devices, &(&1.device_public_key == "noise-otp-123"))
+      assert DateTime.compare(device2.last_handshake_at, first_handshake) != :lt
+    end
+  end
+
+  describe "OIDC device registration" do
+    test "complete_oidc/1 associates device by Noise key" do
+      {:ok, %{account: account}} =
+        Messngr.complete_oidc(%{
+          "provider" => "example",
+          "subject" => "oidc-device-1",
+          "email" => "oidc-device@example.com",
+          "name" => "OIDC Device",
+          "device_id" => "noise-oidc-1"
+        })
+
+      assert [%{device_public_key: "noise-oidc-1"}] =
+               Enum.map(account.devices, &%{device_public_key: &1.device_public_key})
+
+      {:ok, %{account: account2}} =
+        Messngr.complete_oidc(%{
+          "provider" => "example",
+          "subject" => "oidc-device-1",
+          "device_public_key" => "noise-oidc-1",
+          "name" => "OIDC Device"
+        })
+
+      device = Enum.find(account2.devices, &(&1.device_public_key == "noise-oidc-1"))
+      assert device.last_handshake_at
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add account device schema, migration, and CRUD/activation helpers to Messngr.Accounts with changelog entry
- preload account devices and wire OTP/OIDC verification flows to register Noise-keyed devices
- cover new behaviours with ExUnit tests for accounts and auth device flows

## Testing
- mix test *(fails: `mix` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea9b0ee1ac832290b95d1976cc75c4