### PR TITLE
Add deploy workflow for Elixir release

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,17 +9,17 @@ on:
 
 env:
   MIX_ENV: prod
-  UBUNTU_VERSION: ubuntu-20.04
-  DEPLOY_PATH: /var/www/hello.yellowduck.be
-  DEPLOY_APP_NAME: hello
-  DEPLOY_DAEMON_NAME: hello-yellowduck-be
+  UBUNTU_VERSION: ubuntu-22.04
+  DEPLOY_PATH: /var/www/msgr.no
+  DEPLOY_APP_NAME: msgr
+  DEPLOY_DAEMON_NAME: msgr-no
 
 permissions:
   contents: write
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Added GitHub Actions deploy workflow that runs on release tags to build the Elixir release, ship it via rsync, and restart the systemd service.
+- Added GitHub Actions deploy workflow that runs on release tags to build the Elixir release, ship it via rsync to `msgr.no`, and restart the systemd service on Ubuntu 22.04 runners.
 - Added Noise transport session and registry modules with NX/IK/XX handshake
   support, session-token generation and registry TTL management, plus
   integration/property tests for handshake, fallback and rekey flows.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds and deploys the Elixir release to the remote host and restarts the systemd service
- document the new deploy workflow in the changelog

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68eaa4a4ffc88322b547bbc3ae458b78