### PR TITLE
Add CLI integration testing for Dart client flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Unreleased
+- Added docker-compose backed integration test suite that boots the backend,
+  exercises the Dart CLI flow for registration/login/team creation and verifies
+  message send/receive over the public APIs via pytest.
+- Exposed an opt-in `MSGR_WEB_LEGACY_ACTOR_HEADERS` runtime flag so integration
+  tests can rely on legacy headers while Noise authentication is still rolling
+  out.
 - Replaced header-based actor resolution with a shared Noise session plug that
   validates tokens against the registry, assigns account/profile/device for
   REST and WebSocket contexts, adds feature-toggled legacy fallback, updates

--- a/backend/config/runtime.exs
+++ b/backend/config/runtime.exs
@@ -36,6 +36,13 @@ bool_env = fn
   value, _default -> String.downcase(value) in ["1", "true", "yes", "on"]
 end
 
+legacy_headers_env = System.get_env("MSGR_WEB_LEGACY_ACTOR_HEADERS")
+
+if legacy_headers_env do
+  allow_legacy_headers = bool_env.(legacy_headers_env, false)
+  config :msgr_web, :legacy_actor_headers, allow_legacy_headers
+end
+
 port_env = fn
   nil, default -> default
   "", default -> default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       POSTGRES_USERNAME: postgres
       POSTGRES_PASSWORD: postgres
       PORT: 4000
+      MSGR_WEB_LEGACY_ACTOR_HEADERS: ${MSGR_WEB_LEGACY_ACTOR_HEADERS:-false}
     working_dir: /app
     command: ["sh", "-c", "mix setup && mix phx.server"]
     volumes:

--- a/flutter_frontend/packages/libmsgr/tool/integration_flow.dart
+++ b/flutter_frontend/packages/libmsgr/tool/integration_flow.dart
@@ -1,0 +1,300 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:libmsgr/libmsgr.dart';
+import 'package:logging/logging.dart';
+
+class MemorySecureStorage implements ASecureStorage {
+  final Map<String, String> _values = {};
+
+  @override
+  Future<bool> containsKey(key) async {
+    return _values.containsKey(key as String);
+  }
+
+  @override
+  Future<void> deleteAll() async {
+    _values.clear();
+  }
+
+  @override
+  Future<void> deleteKey(key) async {
+    _values.remove(key as String);
+  }
+
+  @override
+  Future<Map<String, String>> readAll() async {
+    return Map<String, String>.from(_values);
+  }
+
+  @override
+  Future<String?> readValue(key) async {
+    return _values[key as String];
+  }
+
+  @override
+  Future<String> writeValue(key, value) async {
+    _values[key as String] = value as String;
+    return value as String;
+  }
+}
+
+class MemorySharedPreferences implements ASharedPreferences {
+  final Map<String, Object?> _store = {};
+
+  @override
+  Future<void> clear({Set<String>? allowList}) async {
+    if (allowList == null) {
+      _store.clear();
+    } else {
+      _store.removeWhere((key, value) => !allowList.contains(key));
+    }
+  }
+
+  @override
+  Future<bool> containsKey(String key) async {
+    return _store.containsKey(key);
+  }
+
+  @override
+  Future<Map<String, Object?>> getAll({Set<String>? allowList}) async {
+    if (allowList == null) {
+      return Map<String, Object?>.from(_store);
+    }
+    final result = <String, Object?>{};
+    for (final key in allowList) {
+      if (_store.containsKey(key)) {
+        result[key] = _store[key];
+      }
+    }
+    return result;
+  }
+
+  @override
+  Future<bool?> getBool(String key) async {
+    final value = _store[key];
+    if (value is bool) {
+      return value;
+    }
+    return null;
+  }
+
+  @override
+  Future<double?> getDouble(String key) async {
+    final value = _store[key];
+    if (value is double) {
+      return value;
+    }
+    if (value is num) {
+      return value.toDouble();
+    }
+    return null;
+  }
+
+  @override
+  Future<int?> getInt(String key) async {
+    final value = _store[key];
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.toInt();
+    }
+    return null;
+  }
+
+  @override
+  Future<Set<String>> getKeys({Set<String>? allowList}) async {
+    if (allowList == null) {
+      return _store.keys.toSet();
+    }
+    return _store.keys.where((key) => allowList.contains(key)).toSet();
+  }
+
+  @override
+  Future<String?> getString(String key) async {
+    final value = _store[key];
+    if (value is String) {
+      return value;
+    }
+    return null;
+  }
+
+  @override
+  Future<List<String>?> getStringList(String key) async {
+    final value = _store[key];
+    if (value is List<String>) {
+      return List<String>.from(value);
+    }
+    return null;
+  }
+
+  @override
+  Future<void> remove(String key) async {
+    _store.remove(key);
+  }
+
+  @override
+  Future<void> setBool(String key, bool value) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<void> setDouble(String key, double value) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<void> setInt(String key, int value) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<void> setString(String key, String value) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<void> setStringList(String key, List<String> value) async {
+    _store[key] = List<String>.from(value);
+  }
+}
+
+class FakeDeviceInfo implements ADeviceInfo {
+  FakeDeviceInfo(this.deviceId);
+
+  final String deviceId;
+
+  Map<String, dynamic> get info => {
+        'platform': 'integration-test',
+        'platformVersion': Platform.version,
+        'model': 'cli-driver',
+        'os': Platform.operatingSystem,
+        'osVersion': Platform.operatingSystemVersion,
+        'deviceId': deviceId,
+      };
+
+  Future<Map<String, dynamic>> appInfo() async {
+    return {
+      'appName': 'integration-cli',
+      'appVersion': '0.0.1',
+      'buildNumber': 'test',
+    };
+  }
+
+  @override
+  Future<Map<dynamic, dynamic>> extractInformation() async {
+    return Map<dynamic, dynamic>.from(info);
+  }
+}
+
+Future<void> main(List<String> args) async {
+  Logger.root.level = Level.INFO;
+  Logger.root.onRecord.listen((event) {
+    stderr.writeln('[${event.level.name}] ${event.loggerName}: ${event.message}');
+  });
+
+  final timestamp = DateTime.now().millisecondsSinceEpoch;
+  final email = 'integration+$timestamp@example.com';
+  final teamName = 'integration$timestamp';
+  final username = 'integration_${timestamp.toRadixString(36)}';
+
+  final memorySecureStorage = MemorySecureStorage();
+  final memorySharedPreferences = MemorySharedPreferences();
+  final fakeDeviceInfo = FakeDeviceInfo('device-$timestamp');
+
+  final lib = LibMsgr();
+  lib.secureStorage = memorySecureStorage;
+  lib.sharedPreferences = memorySharedPreferences;
+  lib.deviceInfoInstance = fakeDeviceInfo;
+
+  try {
+    await lib.bootstrapLibrary();
+
+    final registration = RegistrationService();
+    final appInfo = await fakeDeviceInfo.appInfo();
+    registration.updateCachedContext(
+      deviceInfo: fakeDeviceInfo.info,
+      appInfo: appInfo,
+    );
+    await registration.maybeRegisterDevice(
+      deviceInfo: fakeDeviceInfo.info,
+      appInfo: appInfo,
+    );
+
+    final challenge =
+        await registration.requestForSignInCodeEmail(email);
+    if (challenge == null || challenge.debugCode == null) {
+      throw StateError('Failed to obtain OTP challenge for $email');
+    }
+
+    final user = await registration.submitEmailCodeForToken(
+      challengeId: challenge.id,
+      code: challenge.debugCode!,
+      displayName: 'Integration $timestamp',
+    );
+
+    if (user == null) {
+      throw StateError('Failed to exchange OTP for user session');
+    }
+
+    final authRepo = lib.authRepository as AuthRepository;
+
+    final team = await authRepo.createNewTeam(
+      teamName,
+      'Integration test team created at $timestamp',
+      user.accessToken,
+    );
+
+    if (team == null) {
+      throw StateError('Failed to create team $teamName');
+    }
+
+    final selection = await authRepo.selectTeam(team.name, user.accessToken);
+    if (selection == null) {
+      throw StateError('Failed to select team ${team.name}');
+    }
+
+    final teamAccessToken = selection['teamAccessToken'] as String?;
+    if (teamAccessToken == null || teamAccessToken.isEmpty) {
+      throw StateError('Team access token missing in selection response');
+    }
+
+    String? profileId = (selection['profile'] as Map<String, dynamic>?)?['id']
+        as String?;
+
+    if (profileId == null) {
+      final profile = await authRepo.createProfile(
+        team.name,
+        teamAccessToken,
+        username,
+        'Integration',
+        'Tester',
+      );
+      if (profile == null || profile.id == null) {
+        throw StateError('Failed to create profile for team ${team.name}');
+      }
+      profileId = profile.id;
+    }
+
+    final teams = await authRepo.listMyTeams(user.accessToken);
+
+    final output = {
+      'email': email,
+      'userId': user.uid,
+      'teamId': team.id,
+      'teamName': team.name,
+      'profileId': profileId,
+      'teamAccessToken': teamAccessToken,
+      'teamsCount': teams.length,
+      'teamHost': '${team.name}.teams.7f000001.nip.io:4080',
+    };
+
+    stdout.writeln(jsonEncode(output));
+  } catch (error, stackTrace) {
+    stderr.writeln('Integration flow failed: $error');
+    stderr.writeln(stackTrace);
+    exitCode = 1;
+  }
+}

--- a/integration_tests/test_cli_flow.py
+++ b/integration_tests/test_cli_flow.py
@@ -1,0 +1,200 @@
+"""End-to-end integration tests for the CLI client against the dockerised backend."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCKER_COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+LIBMSGR_PACKAGE_DIR = REPO_ROOT / "flutter_frontend" / "packages" / "libmsgr"
+DEFAULT_TIMEOUT = 180
+
+
+def _http_request(
+    method: str,
+    url: str,
+    *,
+    data: Optional[Dict[str, Any]] = None,
+    headers: Optional[Dict[str, str]] = None,
+    timeout: int = 15,
+) -> Dict[str, Any]:
+    body: Optional[bytes] = None
+    if data is not None:
+        body = json.dumps(data).encode("utf-8")
+    request = urllib.request.Request(url, data=body, method=method.upper())
+    request.add_header("Accept", "application/json")
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    if headers:
+        for key, value in headers.items():
+            request.add_header(key, value)
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = response.read()
+            if not payload:
+                return {}
+            return json.loads(payload.decode("utf-8"))
+    except urllib.error.HTTPError as exc:  # pragma: no cover - integration behaviour
+        details = exc.read().decode("utf-8", errors="replace")
+        raise AssertionError(
+            f"HTTP {exc.code} for {method} {url}: {details}"
+        ) from exc
+
+
+def _wait_for_http(url: str, *, timeout: int = DEFAULT_TIMEOUT) -> None:
+    start = time.time()
+    last_error: Optional[Exception] = None
+    while time.time() - start < timeout:
+        try:
+            request = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(request, timeout=5) as response:
+                if response.status in {200, 201, 202, 400, 401, 403, 404}:
+                    return
+        except Exception as exc:  # pragma: no cover - integration behaviour
+            last_error = exc
+            time.sleep(2)
+    raise TimeoutError(f"Timed out waiting for {url}") from last_error
+
+
+@pytest.fixture(scope="session")
+def backend_stack() -> Dict[str, Any]:
+    if shutil.which("docker") is None:
+        pytest.skip("Docker is required to run the integration backend stack")
+
+    env = os.environ.copy()
+    env.setdefault("MSGR_WEB_LEGACY_ACTOR_HEADERS", "true")
+
+    up_cmd = [
+        "docker",
+        "compose",
+        "-f",
+        str(DOCKER_COMPOSE_FILE),
+        "up",
+        "-d",
+        "db",
+        "stonemq",
+        "backend",
+    ]
+    subprocess.run(up_cmd, check=True, cwd=REPO_ROOT, env=env)
+
+    try:
+        _wait_for_http("http://auth.7f000001.nip.io:4080/", timeout=DEFAULT_TIMEOUT)
+        yield {"env": env}
+    finally:
+        down_cmd = [
+            "docker",
+            "compose",
+            "-f",
+            str(DOCKER_COMPOSE_FILE),
+            "down",
+            "--volumes",
+        ]
+        subprocess.run(down_cmd, check=False, cwd=REPO_ROOT, env=env)
+
+
+def _run_cli_flow(env: Dict[str, str]) -> Dict[str, Any]:
+    if shutil.which("dart") is None:
+        pytest.skip("Dart SDK is required to run the CLI integration flow")
+
+    subprocess.run(["dart", "pub", "get"], check=True, cwd=LIBMSGR_PACKAGE_DIR, env=env)
+
+    process = subprocess.run(
+        ["dart", "run", "tool/integration_flow.dart"],
+        check=True,
+        cwd=LIBMSGR_PACKAGE_DIR,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    stdout = process.stdout.strip().splitlines()
+    if not stdout:
+        raise AssertionError("integration_flow.dart produced no output")
+
+    try:
+        return json.loads(stdout[-1])
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise AssertionError(
+            "Failed to parse integration flow output as JSON."
+        ) from exc
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("backend_stack")
+def test_cli_can_register_login_and_exchange_messages(backend_stack: Dict[str, Any]) -> None:
+    env = backend_stack["env"]
+    flow_output = _run_cli_flow(env)
+
+    required_keys = {
+        "email",
+        "userId",
+        "teamId",
+        "teamName",
+        "profileId",
+        "teamAccessToken",
+        "teamHost",
+    }
+    missing = required_keys.difference(flow_output.keys())
+    assert not missing, f"integration flow output missing keys: {missing}"
+
+    team_host = flow_output["teamHost"]
+    team_base = f"http://{team_host}"
+    conversation_body = {
+        "kind": "channel",
+        "topic": "Integration Test Channel",
+        "participant_ids": [flow_output["profileId"]],
+        "structure_type": "channel",
+    }
+
+    auth_headers = {
+        "Authorization": f"Bearer {flow_output['teamAccessToken']}",
+        "X-Account-Id": flow_output["userId"],
+        "X-Profile-Id": flow_output["profileId"],
+    }
+
+    conversation_response = _http_request(
+        "POST",
+        f"{team_base}/api/conversations",
+        data=conversation_body,
+        headers=auth_headers,
+    )
+
+    conversation_id = conversation_response.get("data", {}).get("id")
+    assert conversation_id, "Conversation creation did not return an ID"
+
+    message_body = {
+        "message": {
+            "kind": "text",
+            "body": "Hello from the integration suite",
+        }
+    }
+
+    _http_request(
+        "POST",
+        f"{team_base}/api/conversations/{conversation_id}/messages",
+        data=message_body,
+        headers=auth_headers,
+    )
+
+    history = _http_request(
+        "GET",
+        f"{team_base}/api/conversations/{conversation_id}/messages",
+        headers=auth_headers,
+    )
+
+    messages = history.get("data", [])
+    assert any(msg.get("body") == "Hello from the integration suite" for msg in messages), (
+        "Expected message not found in conversation history"
+    )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: marks tests that spin up external infrastructure and may be slow (deselect with '-m "not integration"')


### PR DESCRIPTION
## Summary
- add a Dart integration driver that uses libmsgr to register a device, log in, create a team, and surface the resulting session details
- introduce a pytest-based docker-compose harness that boots the backend, runs the Dart flow, and verifies conversation/message APIs
- expose an opt-in MSGR_WEB_LEGACY_ACTOR_HEADERS runtime flag and register the pytest integration marker

## Testing
- pytest integration_tests/test_cli_flow.py -k integration --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68eab6f1d1448322baa7524cdbde2e84