### PR TITLE
feat(flutter): add cupertino contact views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@
 - Enriched the shared msgr message domain with bubble styling, curated theme palettes, and runtime theme switching helpers for every message variant.
 - Redesignet Flutter-hjemmeskjermen med et responsivt oppsett for mobil, nettbrett og desktop, komplett med gradient-sidefelt, innboks-panel og handlingslinje.
 - La til widgettester for brytepunktene og dokumenterte strukturen i `docs/frontend_responsive.md`.
+- La til Cupertino-inspirerte kontaktvisninger i Flutter-klienten (liste, detalj og redigering),
+  systemkontakt-import via `flutter_contacts` og nye widgettester for flyten.
 ## [Unreleased]
 ### Added
 - Konsolidert produktplan og forskningsoppsummering med fokus på chat-MVP, identitet og arkitektur.

--- a/flutter_frontend/lib/features/contacts/domain/contact_entry.dart
+++ b/flutter_frontend/lib/features/contacts/domain/contact_entry.dart
@@ -1,0 +1,56 @@
+import 'dart:typed_data';
+
+import 'package:collection/collection.dart';
+
+/// Represents a contact entry that can be rendered in the UI or synchronised
+/// with the backend.
+class ContactEntry {
+  const ContactEntry({
+    required this.id,
+    required this.displayName,
+    this.givenName,
+    this.familyName,
+    this.phones = const [],
+    this.emails = const [],
+    this.avatar,
+    this.msgrHandle,
+  });
+
+  final String id;
+  final String displayName;
+  final String? givenName;
+  final String? familyName;
+  final List<String> phones;
+  final List<String> emails;
+  final Uint8List? avatar;
+
+  /// Messenger specific username/handle, if present.
+  final String? msgrHandle;
+
+  bool get hasAvatar => avatar != null && avatar!.isNotEmpty;
+
+  String? get primaryPhone => phones.firstOrNull;
+
+  String? get primaryEmail => emails.firstOrNull;
+
+  ContactEntry copyWith({
+    String? displayName,
+    String? givenName,
+    String? familyName,
+    List<String>? phones,
+    List<String>? emails,
+    Uint8List? avatar,
+    String? msgrHandle,
+  }) {
+    return ContactEntry(
+      id: id,
+      displayName: displayName ?? this.displayName,
+      givenName: givenName ?? this.givenName,
+      familyName: familyName ?? this.familyName,
+      phones: phones ?? this.phones,
+      emails: emails ?? this.emails,
+      avatar: avatar ?? this.avatar,
+      msgrHandle: msgrHandle ?? this.msgrHandle,
+    );
+  }
+}

--- a/flutter_frontend/lib/features/contacts/services/contact_importer.dart
+++ b/flutter_frontend/lib/features/contacts/services/contact_importer.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_contacts/flutter_contacts.dart' as system_contacts;
+import 'package:logging/logging.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import '../domain/contact_entry.dart';
+
+/// Abstraction around retrieving contacts from the underlying platform so the
+/// UI can be tested without depending on plugins.
+abstract class ContactImporter {
+  Future<bool> ensurePermission();
+
+  Future<List<ContactEntry>> loadContacts();
+}
+
+class SystemContactImporter implements ContactImporter {
+  SystemContactImporter({
+    Logger? log,
+  }) : _log = log ?? Logger('SystemContactImporter');
+
+  final Logger _log;
+
+  @override
+  Future<bool> ensurePermission() async {
+    if (kIsWeb) {
+      _log.info('Contact permission is unavailable on the web platform.');
+      return false;
+    }
+
+    try {
+      final status = await Permission.contacts.status;
+      if (status.isGranted) {
+        return true;
+      }
+
+      final result = await Permission.contacts.request();
+      return result.isGranted;
+    } catch (error, stackTrace) {
+      _log.warning('Requesting contact permission failed', error, stackTrace);
+      return false;
+    }
+  }
+
+  @override
+  Future<List<ContactEntry>> loadContacts() async {
+    if (kIsWeb) {
+      return const [];
+    }
+
+    try {
+      final contacts = await system_contacts.FlutterContacts.getContacts(
+        withProperties: true,
+        withPhoto: true,
+      );
+
+      return contacts
+          .map(
+            (contact) => ContactEntry(
+              id: contact.id,
+              displayName: contact.displayName,
+              givenName: contact.name.first,
+              familyName: contact.name.last,
+              phones:
+                  contact.phones.map((phone) => phone.number.trim()).toList(),
+              emails:
+                  contact.emails.map((email) => email.address.trim()).toList(),
+              avatar: contact.photo,
+            ),
+          )
+          .toList(growable: false);
+    } catch (error, stackTrace) {
+      _log.severe('Failed to load contacts', error, stackTrace);
+      return const [];
+    }
+  }
+}

--- a/flutter_frontend/lib/ui/pages/contacts/contact_list_page.dart
+++ b/flutter_frontend/lib/ui/pages/contacts/contact_list_page.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/cupertino.dart';
+
+import '../../../features/contacts/domain/contact_entry.dart';
+import '../../../features/contacts/services/contact_importer.dart';
+import 'contact_page.dart';
+import 'widgets/contact_list_tile.dart';
+
+class ContactListPage extends StatefulWidget {
+  const ContactListPage({
+    super.key,
+    ContactImporter? importer,
+  }) : importer = importer ?? SystemContactImporter();
+
+  final ContactImporter importer;
+
+  @override
+  State<ContactListPage> createState() => _ContactListPageState();
+}
+
+enum _ContactListStatus { loading, permissionDenied, empty, ready }
+
+class _ContactListPageState extends State<ContactListPage> {
+  var _status = _ContactListStatus.loading;
+  var _contacts = <ContactEntry>[];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _status = _ContactListStatus.loading);
+    final permitted = await widget.importer.ensurePermission();
+    if (!mounted) return;
+
+    if (!permitted) {
+      setState(() => _status = _ContactListStatus.permissionDenied);
+      return;
+    }
+
+    final contacts = await widget.importer.loadContacts();
+    if (!mounted) return;
+
+    setState(() {
+      _contacts = contacts;
+      _status = contacts.isEmpty
+          ? _ContactListStatus.empty
+          : _ContactListStatus.ready;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final slivers = <Widget>[
+      const CupertinoSliverNavigationBar(
+        largeTitle: Text('Kontakter'),
+      ),
+    ];
+
+    switch (_status) {
+      case _ContactListStatus.loading:
+        slivers.add(
+          const SliverFillRemaining(
+            hasScrollBody: false,
+            child: Center(child: CupertinoActivityIndicator()),
+          ),
+        );
+        break;
+      case _ContactListStatus.permissionDenied:
+        slivers.add(
+          SliverFillRemaining(
+            hasScrollBody: false,
+            child: _PermissionDeniedView(onRetry: _load),
+          ),
+        );
+        break;
+      case _ContactListStatus.empty:
+        slivers.add(
+          const SliverFillRemaining(
+            hasScrollBody: false,
+            child: _EmptyStateView(),
+          ),
+        );
+        break;
+      case _ContactListStatus.ready:
+        slivers.addAll(_buildContactSlivers());
+        break;
+    }
+
+    return CupertinoPageScaffold(
+      child: CustomScrollView(
+        slivers: slivers,
+      ),
+    );
+  }
+
+  List<Widget> _buildContactSlivers() {
+    return [
+      CupertinoSliverRefreshControl(onRefresh: _load),
+      SliverList(
+        delegate: SliverChildBuilderDelegate(
+          (context, index) {
+            final contact = _contacts[index];
+            final showDivider = index < _contacts.length - 1;
+            return Column(
+              children: [
+                ContactListTile(
+                  contact: contact,
+                  onTap: () => _openContact(contact),
+                ),
+                if (showDivider)
+                  Container(
+                    color: CupertinoColors.separator.resolveFrom(context),
+                    height: 0.5,
+                  ),
+              ],
+            );
+          },
+          childCount: _contacts.length,
+        ),
+      ),
+    ];
+  }
+
+  Future<void> _openContact(ContactEntry contact) async {
+    final updated = await Navigator.of(context).push<ContactEntry>(
+      CupertinoPageRoute(
+        builder: (_) => ContactPage(contact: contact),
+      ),
+    );
+
+    if (updated == null) {
+      return;
+    }
+
+    final index = _contacts.indexWhere((element) => element.id == contact.id);
+    if (index == -1) {
+      return;
+    }
+
+    setState(() {
+      _contacts = List<ContactEntry>.of(_contacts)
+        ..[index] = updated;
+    });
+  }
+}
+
+class _PermissionDeniedView extends StatelessWidget {
+  const _PermissionDeniedView({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          const Icon(
+            CupertinoIcons.lock_fill,
+            size: 48,
+            color: CupertinoColors.activeBlue,
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Tillatelse kreves',
+            style: TextStyle(
+              fontSize: 22,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Gi Messengr tilgang til kontaktene dine for å se hvem som allerede er på plattformen.',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 16),
+          ),
+          const SizedBox(height: 24),
+          CupertinoButton.filled(
+            onPressed: onRetry,
+            child: const Text('Prøv igjen'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyStateView extends StatelessWidget {
+  const _EmptyStateView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: const [
+          Icon(
+            CupertinoIcons.person_crop_circle_badge_plus,
+            size: 48,
+            color: CupertinoColors.activeBlue,
+          ),
+          SizedBox(height: 16),
+          Text(
+            'Ingen kontakter ennå',
+            style: TextStyle(
+              fontSize: 22,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          SizedBox(height: 8),
+          Text(
+            'Legg til kontakter manuelt eller importer fra systemet når du har gitt tilgang.',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 16),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_frontend/lib/ui/pages/contacts/contact_page.dart
+++ b/flutter_frontend/lib/ui/pages/contacts/contact_page.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/cupertino.dart';
+
+import '../../../features/contacts/domain/contact_entry.dart';
+import 'edit_contact_page.dart';
+import 'widgets/contact_avatar.dart';
+
+class ContactPage extends StatelessWidget {
+  const ContactPage({
+    super.key,
+    required this.contact,
+  });
+
+  final ContactEntry contact;
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      child: CustomScrollView(
+        slivers: [
+          CupertinoSliverNavigationBar(
+            largeTitle: Text(contact.displayName),
+            trailing: CupertinoButton(
+              padding: EdgeInsets.zero,
+              onPressed: () async {
+                final updated = await Navigator.of(context).push<ContactEntry>(
+                  CupertinoPageRoute(
+                    builder: (_) => EditContactPage(contact: contact),
+                  ),
+                );
+                if (updated != null) {
+                  Navigator.of(context).pop(updated);
+                }
+              },
+              child: const Text('Endre'),
+            ),
+          ),
+          SliverFillRemaining(
+            hasScrollBody: false,
+            child: _ContactDetailView(contact: contact),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ContactDetailView extends StatelessWidget {
+  const _ContactDetailView({required this.contact});
+
+  final ContactEntry contact;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Column(
+              children: [
+                ContactAvatar(contact: contact, size: 96),
+                const SizedBox(height: 12),
+                Text(
+                  contact.displayName,
+                  style: const TextStyle(
+                    fontSize: 26,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                if (contact.msgrHandle != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 6),
+                    child: Text(
+                      '@${contact.msgrHandle}',
+                      style: TextStyle(
+                        color: CupertinoColors.secondaryLabel
+                            .resolveFrom(context),
+                        fontSize: 16,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 32),
+          if (contact.phones.isNotEmpty)
+            _DetailSection(
+              title: 'Telefon',
+              values: contact.phones,
+            ),
+          if (contact.emails.isNotEmpty)
+            _DetailSection(
+              title: 'E-post',
+              values: contact.emails,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DetailSection extends StatelessWidget {
+  const _DetailSection({required this.title, required this.values});
+
+  final String title;
+  final List<String> values;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: CupertinoColors.secondaryLabel.resolveFrom(context),
+            ),
+          ),
+          const SizedBox(height: 8),
+          ...values.map(
+            (value) => Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 16),
+              margin: const EdgeInsets.only(bottom: 12),
+              decoration: BoxDecoration(
+                color:
+                    CupertinoColors.secondarySystemGroupedBackground.resolveFrom(
+                  context,
+                ),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Text(
+                value,
+                style: const TextStyle(fontSize: 17),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_frontend/lib/ui/pages/contacts/edit_contact_page.dart
+++ b/flutter_frontend/lib/ui/pages/contacts/edit_contact_page.dart
@@ -1,0 +1,300 @@
+import 'package:flutter/cupertino.dart';
+
+import '../../../features/contacts/domain/contact_entry.dart';
+
+class EditContactPage extends StatefulWidget {
+  const EditContactPage({
+    super.key,
+    required this.contact,
+    this.onSubmit,
+  });
+
+  final ContactEntry contact;
+  final ValueChanged<ContactEntry>? onSubmit;
+
+  @override
+  State<EditContactPage> createState() => _EditContactPageState();
+}
+
+class _EditContactPageState extends State<EditContactPage> {
+  late TextEditingController _givenNameController;
+  late TextEditingController _familyNameController;
+  late TextEditingController _displayNameController;
+  late TextEditingController _handleController;
+  late List<TextEditingController> _phoneControllers;
+  late List<TextEditingController> _emailControllers;
+
+  @override
+  void initState() {
+    super.initState();
+    final contact = widget.contact;
+    _givenNameController = TextEditingController(text: contact.givenName);
+    _familyNameController = TextEditingController(text: contact.familyName);
+    _displayNameController = TextEditingController(text: contact.displayName);
+    _handleController = TextEditingController(text: contact.msgrHandle);
+    _phoneControllers =
+        contact.phones.map((value) => TextEditingController(text: value)).toList();
+    _emailControllers =
+        contact.emails.map((value) => TextEditingController(text: value)).toList();
+  }
+
+  @override
+  void dispose() {
+    _givenNameController.dispose();
+    _familyNameController.dispose();
+    _displayNameController.dispose();
+    _handleController.dispose();
+    for (final controller in _phoneControllers) {
+      controller.dispose();
+    }
+    for (final controller in _emailControllers) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void _addPhoneField() {
+    setState(() {
+      _phoneControllers.add(TextEditingController());
+    });
+  }
+
+  void _addEmailField() {
+    setState(() {
+      _emailControllers.add(TextEditingController());
+    });
+  }
+
+  void _removePhoneField(int index) {
+    setState(() {
+      final controller = _phoneControllers.removeAt(index);
+      controller.dispose();
+    });
+  }
+
+  void _removeEmailField(int index) {
+    setState(() {
+      final controller = _emailControllers.removeAt(index);
+      controller.dispose();
+    });
+  }
+
+  void _onSave() {
+    final updated = widget.contact.copyWith(
+      displayName: _displayNameController.text.trim().isEmpty
+          ? widget.contact.displayName
+          : _displayNameController.text.trim(),
+      givenName: _givenNameController.text.trim().isEmpty
+          ? null
+          : _givenNameController.text.trim(),
+      familyName: _familyNameController.text.trim().isEmpty
+          ? null
+          : _familyNameController.text.trim(),
+      phones: _phoneControllers
+          .map((controller) => controller.text.trim())
+          .where((value) => value.isNotEmpty)
+          .toList(),
+      emails: _emailControllers
+          .map((controller) => controller.text.trim())
+          .where((value) => value.isNotEmpty)
+          .toList(),
+      msgrHandle: _handleController.text.trim().isEmpty
+          ? null
+          : _handleController.text.trim(),
+    );
+
+    widget.onSubmit?.call(updated);
+    Navigator.of(context).pop(updated);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      navigationBar: const CupertinoNavigationBar(
+        middle: Text('Rediger kontakt'),
+      ),
+      child: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+          children: [
+            _buildNameSection(),
+            const SizedBox(height: 32),
+            _buildPhonesSection(),
+            const SizedBox(height: 32),
+            _buildEmailsSection(),
+            const SizedBox(height: 32),
+            _buildHandleSection(),
+            const SizedBox(height: 40),
+            CupertinoButton.filled(
+              onPressed: _onSave,
+              child: const Text('Lagre'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNameSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Navn',
+          style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 12),
+        CupertinoTextFormFieldRow(
+          key: const Key('contactDisplayNameField'),
+          controller: _displayNameController,
+          placeholder: 'Visningsnavn',
+        ),
+        CupertinoTextFormFieldRow(
+          key: const Key('contactGivenNameField'),
+          controller: _givenNameController,
+          placeholder: 'Fornavn',
+        ),
+        CupertinoTextFormFieldRow(
+          key: const Key('contactFamilyNameField'),
+          controller: _familyNameController,
+          placeholder: 'Etternavn',
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPhonesSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            const Expanded(
+              child: Text(
+                'Telefon',
+                style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+              ),
+            ),
+            CupertinoButton(
+              key: const Key('addPhoneButton'),
+              padding: EdgeInsets.zero,
+              onPressed: _addPhoneField,
+              child: const Icon(CupertinoIcons.add_circled),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        if (_phoneControllers.isEmpty)
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            decoration: BoxDecoration(
+              color: CupertinoColors.secondarySystemGroupedBackground
+                  .resolveFrom(context),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: const Text('Ingen telefonnumre lagt til'),
+          ),
+        ...List.generate(_phoneControllers.length, (index) {
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Row(
+              children: [
+                Expanded(
+                  child: CupertinoTextFormFieldRow(
+                    key: Key('phoneField_$index'),
+                    controller: _phoneControllers[index],
+                    placeholder: '+47 123 45 678',
+                    keyboardType: TextInputType.phone,
+                  ),
+                ),
+                CupertinoButton(
+                  key: Key('removePhoneButton_$index'),
+                  padding: EdgeInsets.zero,
+                  onPressed: () => _removePhoneField(index),
+                  child: const Icon(CupertinoIcons.minus_circle),
+                ),
+              ],
+            ),
+          );
+        }),
+      ],
+    );
+  }
+
+  Widget _buildEmailsSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            const Expanded(
+              child: Text(
+                'E-post',
+                style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+              ),
+            ),
+            CupertinoButton(
+              key: const Key('addEmailButton'),
+              padding: EdgeInsets.zero,
+              onPressed: _addEmailField,
+              child: const Icon(CupertinoIcons.add_circled),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        if (_emailControllers.isEmpty)
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            decoration: BoxDecoration(
+              color: CupertinoColors.secondarySystemGroupedBackground
+                  .resolveFrom(context),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: const Text('Ingen e-postadresser lagt til'),
+          ),
+        ...List.generate(_emailControllers.length, (index) {
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Row(
+              children: [
+                Expanded(
+                  child: CupertinoTextFormFieldRow(
+                    key: Key('emailField_$index'),
+                    controller: _emailControllers[index],
+                    placeholder: 'navn@msgr.no',
+                    keyboardType: TextInputType.emailAddress,
+                  ),
+                ),
+                CupertinoButton(
+                  key: Key('removeEmailButton_$index'),
+                  padding: EdgeInsets.zero,
+                  onPressed: () => _removeEmailField(index),
+                  child: const Icon(CupertinoIcons.minus_circle),
+                ),
+              ],
+            ),
+          );
+        }),
+      ],
+    );
+  }
+
+  Widget _buildHandleSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Msgr-handle',
+          style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 12),
+        CupertinoTextFormFieldRow(
+          key: const Key('contactHandleField'),
+          controller: _handleController,
+          placeholder: 'brukernavn',
+          prefix: const Text('@'),
+        ),
+      ],
+    );
+  }
+}

--- a/flutter_frontend/lib/ui/pages/contacts/widgets/contact_avatar.dart
+++ b/flutter_frontend/lib/ui/pages/contacts/widgets/contact_avatar.dart
@@ -1,0 +1,107 @@
+import 'dart:typed_data';
+
+import 'package:flutter/cupertino.dart';
+import 'package:characters/characters.dart';
+
+import '../../../../features/contacts/domain/contact_entry.dart';
+
+class ContactAvatar extends StatelessWidget {
+  const ContactAvatar({
+    super.key,
+    required this.contact,
+    this.size = 48,
+  });
+
+  final ContactEntry contact;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    if (contact.hasAvatar) {
+      return _ImageAvatar(avatar: contact.avatar!, size: size);
+    }
+
+    return _InitialsAvatar(
+      displayName: contact.displayName,
+      size: size,
+    );
+  }
+}
+
+class _ImageAvatar extends StatelessWidget {
+  const _ImageAvatar({required this.avatar, required this.size});
+
+  final Uint8List avatar;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(size / 2),
+      child: Image.memory(
+        avatar,
+        width: size,
+        height: size,
+        fit: BoxFit.cover,
+      ),
+    );
+  }
+}
+
+class _InitialsAvatar extends StatelessWidget {
+  const _InitialsAvatar({required this.displayName, required this.size});
+
+  final String displayName;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final initials = _initialsFromName(displayName);
+    final color = _colorFromName(displayName);
+
+    return Container(
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(size / 2),
+      ),
+      child: Text(
+        initials,
+        style: TextStyle(
+          color: CupertinoColors.white,
+          fontSize: size * 0.42,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  static String _initialsFromName(String name) {
+    final parts = name.trim().split(RegExp(r'\s+'));
+    if (parts.length == 1) {
+      return parts.first.isEmpty
+          ? '?'
+          : parts.first.characters.take(2).toString().toUpperCase();
+    }
+
+    final first = parts.first.isNotEmpty ? parts.first.characters.first : '';
+    final last = parts.last.isNotEmpty ? parts.last.characters.first : '';
+    final initials = (first + last).trim();
+    return initials.isEmpty ? '?' : initials.toUpperCase();
+  }
+
+  static Color _colorFromName(String name) {
+    final normalized = name.toLowerCase().codeUnits.fold<int>(0, (prev, code) => prev + code);
+    final hue = (normalized % 360).toDouble();
+    final hslColor = HSLColor.fromAHSL(1, hue, 0.45, 0.65);
+    final materialColor = hslColor.toColor();
+    return Color.fromARGB(
+      255,
+      materialColor.red,
+      materialColor.green,
+      materialColor.blue,
+    );
+  }
+}

--- a/flutter_frontend/lib/ui/pages/contacts/widgets/contact_list_tile.dart
+++ b/flutter_frontend/lib/ui/pages/contacts/widgets/contact_list_tile.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart' show Icons;
+
+import '../../../../features/contacts/domain/contact_entry.dart';
+import 'contact_avatar.dart';
+
+class ContactListTile extends StatelessWidget {
+  const ContactListTile({
+    super.key,
+    required this.contact,
+    required this.onTap,
+  });
+
+  final ContactEntry contact;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final subtitle = contact.primaryPhone ?? contact.primaryEmail ?? '';
+
+    return CupertinoButton(
+      padding: EdgeInsets.zero,
+      onPressed: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: CupertinoColors.systemBackground.resolveFrom(context),
+          border: Border(
+            bottom: BorderSide(
+              color: CupertinoColors.separator.resolveFrom(context),
+              width: 0.5,
+            ),
+          ),
+        ),
+        child: Row(
+          children: [
+            ContactAvatar(contact: contact),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    contact.displayName,
+                    style: const TextStyle(
+                      fontSize: 17,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (subtitle.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        subtitle,
+                        style: TextStyle(
+                          fontSize: 15,
+                          color: CupertinoColors.secondaryLabel
+                              .resolveFrom(context),
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const Icon(CupertinoIcons.chevron_forward, size: 18),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_frontend/pubspec.lock
+++ b/flutter_frontend/pubspec.lock
@@ -511,6 +511,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.2"
+  flutter_contacts:
+    dependency: "direct main"
+    description:
+      name: flutter_contacts
+      sha256: "388d32cd33f16640ee169570128c933b45f3259bddbfae7a100bb49e5ffea9ae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.9+2"
   flutter_cache_manager:
     dependency: transitive
     description:

--- a/flutter_frontend/pubspec.yaml
+++ b/flutter_frontend/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   #geolocator: ^13.0.1
   #location: ^7.0.0
   permission_handler: ^11.3.1
+  flutter_contacts: ^1.1.7
   device_info_plus: ^10.1.2
   package_info_plus: ^8.0.0
   visibility_detector: ^0.4.0+2

--- a/flutter_frontend/test/ui/pages/contacts/contact_pages_test.dart
+++ b/flutter_frontend/test/ui/pages/contacts/contact_pages_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:messngr/features/contacts/domain/contact_entry.dart';
+import 'package:messngr/features/contacts/services/contact_importer.dart';
+import 'package:messngr/ui/pages/contacts/contact_list_page.dart';
+import 'package:messngr/ui/pages/contacts/edit_contact_page.dart';
+
+class _FakeContactImporter implements ContactImporter {
+  _FakeContactImporter({
+    required this.permissionGranted,
+    this.contacts = const [],
+  });
+
+  final bool permissionGranted;
+  final List<ContactEntry> contacts;
+
+  @override
+  Future<bool> ensurePermission() async {
+    return permissionGranted;
+  }
+
+  @override
+  Future<List<ContactEntry>> loadContacts() async {
+    return contacts;
+  }
+}
+
+void main() {
+  group('ContactListPage', () {
+    testWidgets('renders contacts when permission granted', (tester) async {
+      final importer = _FakeContactImporter(
+        permissionGranted: true,
+        contacts: [
+          const ContactEntry(
+            id: '1',
+            displayName: 'Ola Nordmann',
+            phones: ['+47 555 66 777'],
+          ),
+          const ContactEntry(
+            id: '2',
+            displayName: 'Kari Nordmann',
+            emails: ['kari@example.com'],
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        CupertinoApp(home: ContactListPage(importer: importer)),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Ola Nordmann'), findsOneWidget);
+      expect(find.text('Kari Nordmann'), findsOneWidget);
+      expect(find.text('+47 555 66 777'), findsOneWidget);
+      expect(find.text('kari@example.com'), findsOneWidget);
+    });
+
+    testWidgets('shows permission messaging when denied', (tester) async {
+      final importer = _FakeContactImporter(permissionGranted: false);
+
+      await tester.pumpWidget(
+        CupertinoApp(home: ContactListPage(importer: importer)),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Tillatelse kreves'), findsOneWidget);
+      expect(find.text('Prøv igjen'), findsOneWidget);
+    });
+  });
+
+  group('EditContactPage', () {
+    testWidgets('saves updated fields and notifies listener', (tester) async {
+      const initialContact = ContactEntry(
+        id: '1',
+        displayName: 'Ukjent',
+      );
+
+      ContactEntry? savedContact;
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: EditContactPage(
+            contact: initialContact,
+            onSubmit: (contact) => savedContact = contact,
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('contactDisplayNameField')),
+        'Oda Messengr',
+      );
+      await tester.enterText(
+        find.byKey(const Key('contactGivenNameField')),
+        'Oda',
+      );
+      await tester.enterText(
+        find.byKey(const Key('contactFamilyNameField')),
+        'Messengr',
+      );
+      await tester.enterText(
+        find.byKey(const Key('contactHandleField')),
+        'oda',
+      );
+
+      await tester.tap(find.byKey(const Key('addPhoneButton')));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byKey(const Key('phoneField_0')), '+47 123 45 678');
+
+      await tester.tap(find.byKey(const Key('addEmailButton')));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byKey(const Key('emailField_0')), 'oda@msgr.no');
+
+      await tester.tap(find.text('Lagre'));
+      await tester.pumpAndSettle();
+
+      expect(savedContact, isNotNull);
+      expect(savedContact!.displayName, 'Oda Messengr');
+      expect(savedContact!.givenName, 'Oda');
+      expect(savedContact!.familyName, 'Messengr');
+      expect(savedContact!.msgrHandle, 'oda');
+      expect(savedContact!.phones, ['+47 123 45 678']);
+      expect(savedContact!.emails, ['oda@msgr.no']);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a contact domain model plus a system importer using flutter_contacts
- introduce Cupertino-styled contact list, detail, and edit pages with reusable widgets
- cover the new UI with widget tests and document the feature in the changelog

## Testing
- `flutter test` *(fails: flutter tool is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eac85b57708322932495e304383b3c