### PR TITLE
Integrate Snapchat Camera Kit across mobile clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   new email/phone/OIDC credentials to an existing account via `account_id`, with
   safeguards against cross-account hijacking, refreshed docs and regression
   tests for linking flows.
+- Added Snapchat Camera Kit capture pipeline to the Flutter chat composer with
+  environment-based configuration, Android/iOS method-channel bridges,
+  fallbacks for unsupported platforms, native dependency wiring, unit tests and
+  documentation describing setup requirements.
 - Enforced Noise-handshake attestasjonskrav for OTP (`/api/auth/verify`) med
   Telemetry-instrumentering, fullstack tester (unit/integration) for happy-path,
   feilscenarier (feil signatur, utløpt session, rekey) i både `msgr` og

--- a/flutter_frontend/README.md
+++ b/flutter_frontend/README.md
@@ -72,3 +72,38 @@ flutter run \
 Standardverdiene matcher docker-compose-oppsettet (`root@example.com` /
 `Complexpass#123`). Under kjøring kan du endre strømmen eller deaktivere logging
 med `LoggingEnvironment.instance.override(enabled: false);`.
+
+## Snapchat Camera Kit
+
+Messngr kan bruke [Snapchat Camera Kit](https://developer.snap.com/docs/camera-kit/)
+for å tilby linser når brukere tar bilder eller video i chatte-komponisten.
+Funksjonen er som standard deaktivert og må konfigureres med Snapchat-nøkler
+via `--dart-define`.
+
+Tilgjengelige parametere:
+
+```
+MSGR_CAMERA_KIT_ENABLED=true
+MSGR_CAMERA_KIT_APPLICATION_ID=<Snapchat application id>
+MSGR_CAMERA_KIT_API_TOKEN=<Camera Kit API token>
+MSGR_CAMERA_KIT_LENS_GROUP_IDS=<kommaseparert liste med lens-grupper>
+```
+
+Eksempel på oppstart med Camera Kit aktivert:
+
+```
+flutter run \
+  --dart-define=MSGR_CAMERA_KIT_ENABLED=true \
+  --dart-define=MSGR_CAMERA_KIT_APPLICATION_ID=com.example.myapp \
+  --dart-define=MSGR_CAMERA_KIT_API_TOKEN=sn-xxxxxxxx \
+  --dart-define=MSGR_CAMERA_KIT_LENS_GROUP_IDS=abcd1234,efgh5678
+```
+
+### Native oppsett
+
+- **Android:** avhenger av `com.snap.camerakit:support-camera-activity`. Legg inn
+  Camera Kit API token og lens-grupper via miljøvariablene ovenfor.
+- **iOS:** Pod-avhengighetene `SCSDKCameraKit` og `SCSDKCameraKitReferenceUI`
+  må installeres. Kjør `pod install` i `ios/` etter at hemmelighetene er lagt
+  inn. Sørg også for at `Info.plist` inneholder oppdaterte beskrivelser for
+  kamera-, mikrofon- og bildebibliotekstilgang.

--- a/flutter_frontend/android/app/build.gradle
+++ b/flutter_frontend/android/app/build.gradle
@@ -42,3 +42,7 @@ android {
 flutter {
     source = "../.."
 }
+
+dependencies {
+    implementation "com.snap.camerakit:support-camera-activity:$cameraKitVersion"
+}

--- a/flutter_frontend/android/app/src/main/kotlin/dev/meeh/messngr/MainActivity.kt
+++ b/flutter_frontend/android/app/src/main/kotlin/dev/meeh/messngr/MainActivity.kt
@@ -1,5 +1,75 @@
 package dev.meeh.messngr
 
-import io.flutter.embedding.android.FlutterActivity
+import android.widget.Toast
+import androidx.core.net.toFile
+import com.snap.camerakit.support.app.CameraActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity: FlutterActivity()
+class MainActivity : FlutterFragmentActivity() {
+
+    private val channelName = "dev.meeh.messngr/snap_camera_kit"
+    private lateinit var methodChannel: MethodChannel
+    private var pendingResult: MethodChannel.Result? = null
+
+    private val captureLauncher = registerForActivityResult(CameraActivity.Capture) { captureResult ->
+        val result = pendingResult ?: return@registerForActivityResult
+        pendingResult = null
+        when (captureResult) {
+            is CameraActivity.Capture.Result.Success.Video -> {
+                val path = captureResult.uri.toFile().absolutePath
+                result.success(mapOf("path" to path, "mime_type" to "video/mp4"))
+            }
+            is CameraActivity.Capture.Result.Success.Image -> {
+                val path = captureResult.uri.toFile().absolutePath
+                result.success(mapOf("path" to path, "mime_type" to "image/jpeg"))
+            }
+            is CameraActivity.Capture.Result.Cancelled -> {
+                result.success(null)
+            }
+            is CameraActivity.Capture.Result.Failure -> {
+                Toast.makeText(this, "Camera Kit failed", Toast.LENGTH_SHORT).show()
+                result.error("failure", "Camera Kit capture failed", null)
+            }
+        }
+    }
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        methodChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
+        methodChannel.setMethodCallHandler(::onMethodCall)
+    }
+
+    private fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "isSupported" -> result.success(true)
+            "openCameraKit" -> openCameraKit(call, result)
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun openCameraKit(call: MethodCall, result: MethodChannel.Result) {
+        if (pendingResult != null) {
+            result.error("in_use", "Camera Kit is already running", null)
+            return
+        }
+
+        val apiToken = call.argument<String>("apiToken")
+        val lensGroupIds = call.argument<List<String>>("lensGroupIds")
+
+        if (apiToken.isNullOrEmpty() || lensGroupIds.isNullOrEmpty()) {
+            result.error("invalid_config", "Camera Kit configuration missing", null)
+            return
+        }
+
+        pendingResult = result
+        captureLauncher.launch(
+            CameraActivity.Configuration.WithLenses(
+                cameraKitApiToken = apiToken,
+                lensGroupIds = lensGroupIds.toTypedArray()
+            )
+        )
+    }
+}

--- a/flutter_frontend/android/build.gradle
+++ b/flutter_frontend/android/build.gradle
@@ -1,3 +1,7 @@
+ext {
+    cameraKitVersion = '1.26.0'
+}
+
 allprojects {
     repositories {
         google()

--- a/flutter_frontend/ios/Podfile
+++ b/flutter_frontend/ios/Podfile
@@ -1,5 +1,4 @@
-# Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -30,6 +29,9 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
+
+  pod 'SCSDKCameraKit', '1.26.0'
+  pod 'SCSDKCameraKitReferenceUI', '1.26.0'
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do

--- a/flutter_frontend/ios/Runner/AppDelegate.swift
+++ b/flutter_frontend/ios/Runner/AppDelegate.swift
@@ -3,11 +3,76 @@ import UIKit
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
+  private let channelName = "dev.meeh.messngr/snap_camera_kit"
+  private var supportedOrientations: UIInterfaceOrientationMask = .allButUpsideDown
+  private var pendingResult: FlutterResult?
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+
+    if let controller = window?.rootViewController as? FlutterViewController {
+      let methodChannel = FlutterMethodChannel(name: channelName, binaryMessenger: controller.binaryMessenger)
+      methodChannel.setMethodCallHandler(handle)
+    }
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  override func application(
+    _ application: UIApplication,
+    supportedInterfaceOrientationsFor window: UIWindow?
+  ) -> UIInterfaceOrientationMask {
+    supportedOrientations
+  }
+
+  private func handle(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "isSupported":
+      result(true)
+    case "openCameraKit":
+      guard pendingResult == nil else {
+        result(FlutterError(code: "in_use", message: "Camera Kit already presented", details: nil))
+        return
+      }
+
+      guard let configuration = SnapCameraKitConfiguration(arguments: call.arguments) else {
+        result(FlutterError(code: "invalid_config", message: "Missing Camera Kit configuration", details: nil))
+        return
+      }
+
+      guard let controller = window?.rootViewController as? FlutterViewController else {
+        result(FlutterError(code: "no_controller", message: "Missing Flutter controller", details: nil))
+        return
+      }
+
+      pendingResult = result
+      SnapCameraKitBridge.present(
+        from: controller,
+        configuration: configuration,
+        result: { [weak self] payload in
+          self?.pendingResult?(payload)
+          self?.pendingResult = nil
+        },
+        cancellation: { [weak self] in
+          self?.pendingResult?(nil)
+          self?.pendingResult = nil
+        }
+      )
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+}
+
+extension AppDelegate: AppOrientationDelegate {
+  func lockOrientation(_ orientation: UIInterfaceOrientationMask) {
+    supportedOrientations = orientation
+  }
+
+  func unlockOrientation() {
+    supportedOrientations = .allButUpsideDown
   }
 }

--- a/flutter_frontend/ios/Runner/FlutterCameraViewController.swift
+++ b/flutter_frontend/ios/Runner/FlutterCameraViewController.swift
@@ -1,0 +1,726 @@
+//  Copyright Snap Inc. All rights reserved.
+
+import AVFoundation
+import AVKit
+import SCSDKCameraKit
+import SCSDKCameraKitReferenceUI
+import UIKit
+
+/// Describes an interface to control app orientation
+public protocol AppOrientationDelegate: AnyObject {
+    /// Lock app orientation
+    /// - Parameter orientation: interface orientation mask to lock orientations to
+    func lockOrientation(_ orientation: UIInterfaceOrientationMask)
+
+    /// Unlock orientation
+    func unlockOrientation()
+}
+
+/// This is the default view controller which handles setting up the camera, lenses, carousel, etc.
+open class FlutterCameraViewController: UIViewController, CameraControllerUIDelegate {
+    // MARK: CameraKit properties
+    
+    /// For Flutter
+    public var onDismiss: (() -> Void)?
+    public var url: URL?
+    public var mimeType: String? = "video"
+    ///
+
+    /// A controller which manages the camera and lenses stack on behalf of the view controller
+    public let cameraController: CameraController
+
+    /// App orientation delegate to control app orientation
+    public weak var appOrientationDelegate: AppOrientationDelegate?
+
+    /// convenience prop to get current interface orientation of application/scene
+    fileprivate var applicationInterfaceOrientation: UIInterfaceOrientation {
+        var interfaceOrientation = UIApplication.shared.statusBarOrientation
+        if
+            #available(iOS 13, *),
+            let sceneOrientation = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation
+        {
+            interfaceOrientation = sceneOrientation
+        }
+        return interfaceOrientation
+    }
+
+    /// convenience prop to get current interface orientation mask to lock device from rotation
+    fileprivate var currentInterfaceOrientationMask: UIInterfaceOrientationMask {
+        switch applicationInterfaceOrientation {
+        case .portrait, .unknown: return .portrait
+        case .portraitUpsideDown: return .portraitUpsideDown
+        case .landscapeLeft: return .landscapeLeft
+        case .landscapeRight: return .landscapeRight
+        @unknown default:
+            return .portrait
+        }
+    }
+
+    // The backing view
+    public let cameraView = CameraView()
+
+    override open func loadView() {
+        view = cameraView
+    }
+
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+    }
+
+    override open func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        cameraController.increaseBrightnessIfNecessary()
+    }
+
+    override open func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        cameraController.restoreBrightnessIfNecessary()
+        if url == nil {
+            onDismiss?()
+        }
+    }
+
+    // MARK: Init
+
+    /// Returns a camera view controller initialized with a camera controller that is configured with a newly created AVCaptureSession stack
+    /// and CameraKit session with the specified configuration and list of group IDs.
+    /// - Parameters:
+    ///   - repoGroups: List of group IDs to observe.
+    ///   - sessionConfig: Config to configure session with application id and api token.
+    ///   Pass this in if you wish to dynamically update or overwrite the application id and api token in the application's `Info.plist`.
+    public convenience init(repoGroups: [String], sessionConfig: SessionConfig? = nil) {
+        // Max size of lens content cache = 500 * 1024 * 1024 = 150MB
+        // 500MB to make sure that some lenses that use large assets such as the ones required for
+        // 3D body tracking (https://lensstudio.snapchat.com/templates/object/3d-body-tracking) have
+        // enough cache space to fit alongside other lenses.
+        let lensesConfig = LensesConfig(cacheConfig: CacheConfig(lensContentMaxSize: 500 * 1024 * 1024))
+        let cameraKit = Session(sessionConfig: sessionConfig, lensesConfig: lensesConfig, errorHandler: nil)
+        let captureSession = AVCaptureSession()
+        self.init(cameraKit: cameraKit, captureSession: captureSession, repoGroups: repoGroups)
+    }
+
+    /// Convenience init to configure a camera controller with a specified AVCaptureSession stack, CameraKit, and list of group IDs.
+    /// - Parameters:
+    ///   - cameraKit: camera kit session
+    ///   - captureSession: a backing AVCaptureSession to use
+    ///   - repoGroups: the group IDs to observe
+    public convenience init(cameraKit: CameraKitProtocol, captureSession: AVCaptureSession, repoGroups: [String]) {
+        let cameraController = CameraController(cameraKit: cameraKit, captureSession: captureSession)
+        cameraController.groupIDs = repoGroups
+        self.init(cameraController: cameraController)
+    }
+
+    /// Initialize the view controller with a preconfigured camera controller
+    /// - Parameter cameraController: the camera controller to use.
+    public init(cameraController: CameraController) {
+        self.cameraController = cameraController
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Overridable Helper
+    
+    /// get message to display in popup view for selected lens
+    /// - Parameter lens: selected lens
+    open func getMessage(lens: Lens) -> String {
+        var text = lens.name ?? lens.id
+
+        if lens.name != nil {
+            text.append("\n\(lens.id)")
+        }
+
+        return text
+    }
+
+    /// Displays a message indicating that a specified lens has been displayed
+    /// - Parameter lens: the lens to display info for.
+    open func showMessage(lens: Lens) {
+        let message = getMessage(lens: lens)
+        cameraView.showMessage(text: message, numberOfLines: message.components(separatedBy: "\n").count)
+    }
+
+    override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        cameraController.cameraKit.videoOrientation = videoOrientation(
+            from: orientation(from: applicationInterfaceOrientation, transform: coordinator.targetTransform))
+    }
+
+    // MARK: Lenses Setup
+
+    /// Apply a specific lens
+    /// - Parameters:
+    ///   - lens: selected lens
+    open func applyLens(_ lens: Lens) {
+        cameraView.activityIndicator.stopAnimating() // stop any loading indicator that may still be going on from previous lens
+        cameraController.applyLens(lens) { [weak self] success in
+            guard let strongSelf = self else { return }
+            if success {
+                print("\(lens.name ?? "Unnamed") (\(lens.id)) Applied")
+
+                DispatchQueue.main.async {
+                    strongSelf.hideAllHints()
+                    strongSelf.showMessage(lens: lens)
+                    strongSelf.cameraView.cameraBottomBar.closeButton.isHidden = false
+                    strongSelf.cameraView.lensLabel.text = lens.name ?? lens.id
+                }
+            }
+        }
+    }
+
+    /// Helper function to clear currently selected lens
+    open func clearLens() {
+        cameraView.activityIndicator.stopAnimating() // stop any loading indicator that may still be going on from current lens
+        cameraController.clearLens(completion: nil)
+        cameraView.cameraBottomBar.closeButton.isHidden = true
+        cameraView.lensLabel.text = ""
+    }
+
+    // MARK: CameraControllerUIDelegate
+
+    open func cameraController(_ controller: CameraController, updatedLenses lenses: [Lens]) {
+        cameraView.carouselView.reloadData()
+        let selectedItem = cameraView.carouselView.selectedItem
+
+        if !(selectedItem is EmptyItem) {
+            cameraView.carouselView.selectItem(selectedItem)
+        }
+    }
+
+    open func cameraControllerRequestedActivityIndicatorShow(_ controller: CameraController) {
+        cameraView.activityIndicator.startAnimating()
+    }
+
+    open func cameraControllerRequestedActivityIndicatorHide(_ controller: CameraController) {
+        cameraView.activityIndicator.stopAnimating()
+    }
+
+    open func cameraControllerRequestedRingLightShow(_ controller: CameraController) {
+        cameraView.ringLightView.isHidden = false
+    }
+
+    open func cameraControllerRequestedRingLightHide(_ controller: CameraController) {
+        cameraView.ringLightView.isHidden = true
+    }
+
+    open func cameraControllerRequestedFlashControlHide(_ controller: CameraController) {
+        cameraView.flashControlView.isHidden = true
+    }
+
+    open func cameraControllerRequestedSnapAttributionViewShow(_ controller: CameraController) {
+        cameraView.snapAttributionView.isHidden = false
+    }
+
+    open func cameraControllerRequestedSnapAttributionViewHide(_ controller: CameraController) {
+        cameraView.snapAttributionView.isHidden = true
+    }
+
+    open func cameraControllerRequestedCameraFlip(_ controller: CameraController) {
+        flip(sender: controller)
+    }
+
+    open func cameraController(
+        _ controller: CameraController, requestedHintDisplay hint: String, for lens: Lens, autohide: Bool
+    ) {
+        guard lens.id == cameraController.currentLens?.id else { return }
+
+        cameraView.hintLabel.text = hint
+        cameraView.hintLabel.layer.removeAllAnimations()
+        cameraView.hintLabel.alpha = 0.0
+
+        UIView.animate(
+            withDuration: 0.5,
+            animations: {
+                self.cameraView.hintLabel.alpha = 1.0
+            }
+        ) { completed in
+            guard autohide, completed else { return }
+            UIView.animate(
+                withDuration: 0.5, delay: 2.0,
+                animations: {
+                    self.cameraView.hintLabel.alpha = 0.0
+                }, completion: nil
+            )
+        }
+    }
+
+    open func cameraController(_ controller: CameraController, requestedHintHideFor lens: Lens) {
+        hideAllHints()
+    }
+
+    private func hideAllHints() {
+        cameraView.hintLabel.layer.removeAllAnimations()
+        cameraView.hintLabel.alpha = 0.0
+    }
+}
+
+// MARK: General Camera Setup
+
+private extension FlutterCameraViewController {
+    /// Calls the relevant setup methods on the camera controller
+    func setup() {
+        cameraController.configure(
+            orientation: videoOrientation(from: applicationInterfaceOrientation),
+            textInputContextProvider: nil,
+            agreementsPresentationContextProvider: nil,
+            completion: { [weak self] in
+                // Re-check adjustment availability and add observer only after completion, because during first setup
+                // permissions may not have been granted yet/the session may not start immediately until permissions
+                // are granted.
+                guard let self else { return }
+                self.updateAdjustmentButtonStatus()
+                self.cameraController.cameraKit.adjustments.processor?.addObserver(self)
+            }
+        )
+        setupActions()
+        cameraController.cameraKit.add(output: cameraView.previewView)
+        cameraController.uiDelegate = self
+        setupSystemNotificationObservers()
+    }
+
+    /// Configures the target actions and delegates needed for the view controller to function
+    func setupActions() {
+        let singleTap = UITapGestureRecognizer(target: self, action: #selector(handleSingleTap(sender:)))
+        cameraView.previewView.addGestureRecognizer(singleTap)
+
+        let doubleTap = UITapGestureRecognizer(target: self, action: #selector(flip(sender:)))
+        doubleTap.numberOfTapsRequired = 2
+        cameraView.previewView.addGestureRecognizer(doubleTap)
+
+        let pinchGestureRecognizer = UIPinchGestureRecognizer(target: self, action: #selector(zoom(sender:)))
+        cameraView.previewView.addGestureRecognizer(pinchGestureRecognizer)
+        cameraView.previewView.automaticallyConfiguresTouchHandler = true
+
+        cameraView.cameraBottomBar.closeButton.addTarget(
+            self, action: #selector(closeButtonPressed(_:)), for: .touchUpInside
+        )
+        cameraView.cameraBottomBar.snapButton.addTarget(
+            self, action: #selector(snapchatButtonPressed(_:)), for: .touchUpInside
+        )
+
+        cameraView.cameraActionsView.flipCameraButton.addTarget(
+            self, action: #selector(flip(sender:)), for: .touchUpInside
+        )
+
+        setupFlashButtons()
+        setupToneMapAdjustmentButtons()
+        setupPortraitAdjustmentButtons()
+
+        cameraView.carouselView.delegate = self
+        cameraView.carouselView.dataSource = self
+
+        cameraView.cameraButton.delegate = self
+        cameraView.cameraButton.allowWhileRecording = [doubleTap, pinchGestureRecognizer]
+
+        cameraView.mediaPickerView.provider = cameraController.lensMediaProvider
+        cameraView.mediaPickerView.delegate = cameraController
+        cameraController.lensMediaProvider.uiDelegate = cameraView.mediaPickerView
+
+        cameraView.toneMapControlView.delegate = cameraController
+        cameraView.portraitControlView.delegate = cameraController
+
+        cameraView.flashControlView.delegate = self
+    }
+}
+
+// MARK: Camera Bottom Bar
+
+extension FlutterCameraViewController {
+    /// Clears the current lens and scrolls the carousel back to the "empty" item.
+    /// - Parameter sender: the caller
+    @objc
+    private func closeButtonPressed(_ sender: UIButton) {
+        clearLens()
+        cameraView.carouselView.selectItem(EmptyItem())
+    }
+
+    /// Opens Snapchat to the lens or profile specified
+    /// - Parameter sender: the caller
+    @objc
+    private func snapchatButtonPressed(_ sender: UIButton) {
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+        if let lens = cameraController.currentLens {
+            let lensAction = UIAlertAction(title: "Open Lens in Snapchat", style: .default) { _ in
+                self.cameraController.snapchatDelegate?.cameraKitViewController(self, openSnapchat: .lens(lens))
+            }
+
+            alertController.addAction(lensAction)
+        }
+
+        let profileAction = UIAlertAction(title: "View Profile on Snapchat", style: .default) { _ in
+            self.cameraController.snapchatDelegate?.cameraKitViewController(self, openSnapchat: .profile)
+        }
+
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+
+        alertController.addAction(profileAction)
+        alertController.addAction(cancelAction)
+        present(alertController, animated: true, completion: nil)
+    }
+}
+
+// MARK: Single Tap
+
+extension FlutterCameraViewController {
+    /// Handles a single tap gesture by dismissing the tone map control if it is visible and setting the point
+    /// of interest otherwise.
+    /// - Parameter sender: The single tap gesture recognizer.
+    @objc
+    private func handleSingleTap(sender: UITapGestureRecognizer) {
+        if cameraView.isAnyControlVisible {
+            cameraView.hideAllControls()
+        }
+    }
+}
+
+// MARK: Camera Flip
+
+private extension FlutterCameraViewController {
+    /// Flips the camera
+    /// - Parameter sender: the caller
+    @objc
+    func flip(sender: Any) {
+        cameraController.flipCamera()
+        switch cameraController.cameraPosition {
+        case .front:
+            cameraView.cameraActionsView.setupFlashToggleButtonForFront()
+            cameraView.cameraActionsView.flipCameraButton.accessibilityValue = CameraElements.CameraFlip.front
+        case .back:
+            cameraView.cameraActionsView.setupFlashToggleButtonForBack()
+            cameraView.cameraActionsView.flipCameraButton.accessibilityValue = CameraElements.CameraFlip.back
+        default:
+            break
+        }
+    }
+}
+
+// MARK: Adjustment Observer
+
+extension FlutterCameraViewController: AdjustmentsProcessorObserver {
+    public func processorUpdatedAdjustmentsAvailability(_ adjustmentsProcessor: AdjustmentsProcessor) {
+        updateAdjustmentButtonStatus()
+    }
+
+    func updateAdjustmentButtonStatus() {
+        cameraView.cameraActionsView.toneMapActionView.isHidden = !cameraController.isToneMapAdjustmentAvailable
+        cameraView.cameraActionsView.portraitActionView.isHidden = !cameraController.isPortraitAdjustmentAvailable
+    }
+}
+
+// MARK: System Notification Observers
+
+extension FlutterCameraViewController {
+    @objc
+    private func increaseBrightnessIfNecessary() {
+        cameraController.increaseBrightnessIfNecessary()
+    }
+
+    @objc
+    private func restoreBrightnessIfNecessary() {
+        cameraController.restoreBrightnessIfNecessary()
+    }
+
+    private func setupSystemNotificationObservers() {
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(restoreBrightnessIfNecessary), name: UIApplication.willResignActiveNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(increaseBrightnessIfNecessary), name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(restoreBrightnessIfNecessary), name: UIApplication.willTerminateNotification,
+            object: nil
+        )
+    }
+}
+
+// MARK: Tone Map Adjustment
+
+extension FlutterCameraViewController {
+    private func setupToneMapAdjustmentButtons() {
+        cameraView.cameraActionsView.toneMapActionView.isHidden = !cameraController.isToneMapAdjustmentAvailable
+
+        cameraView.cameraActionsView.toneMapActionView.enableAction = { [weak self] in
+            guard let strongSelf = self else { return }
+            let amount = strongSelf.cameraController.enableToneMapAdjustment()
+            if let amount {
+                strongSelf.cameraView.toneMapControlView.intensityValue = amount
+            }
+        }
+
+        cameraView.cameraActionsView.toneMapActionView.disableAction = { [weak self] in
+            guard let strongSelf = self else { return }
+            strongSelf.cameraController.disableToneMapAdjustment()
+        }
+    }
+}
+
+// MARK: Portrait Adjustment
+
+extension FlutterCameraViewController {
+    private func setupPortraitAdjustmentButtons() {
+        cameraView.cameraActionsView.portraitActionView.isHidden = !cameraController.isPortraitAdjustmentAvailable
+
+        cameraView.cameraActionsView.portraitActionView.enableAction = { [weak self] in
+            guard let strongSelf = self else { return }
+            let blur = strongSelf.cameraController.enablePortraitAdjustment()
+            if let blur {
+                strongSelf.cameraView.portraitControlView.intensityValue = blur
+            }
+        }
+
+        cameraView.cameraActionsView.portraitActionView.disableAction = { [weak self] in
+            guard let strongSelf = self else { return }
+            strongSelf.cameraController.disablePortraitAdjustment()
+        }
+    }
+}
+
+// MARK: Camera Zoom
+
+private extension FlutterCameraViewController {
+    /// Zooms the camera based on a pinch gesture
+    /// - Parameter sender: the caller
+    @objc
+    func zoom(sender: UIPinchGestureRecognizer) {
+        switch sender.state {
+        case .changed:
+            cameraController.zoomExistingLevel(by: sender.scale)
+        case .ended:
+            cameraController.finalizeZoom()
+        default:
+            break
+        }
+    }
+}
+
+// MARK: Carousel
+
+extension FlutterCameraViewController: CarouselViewDelegate, CarouselViewDataSource {
+    public func carouselView(_ view: CarouselView, didSelect item: CarouselItem, at index: Int) {
+        // first item is empty item
+        guard index > 0 else {
+            clearLens()
+            return
+        }
+
+        guard let lens = cameraController.cameraKit.lenses.repository.lens(id: item.lensId, groupID: item.groupId)
+        else { return }
+        applyLens(lens)
+    }
+
+    public func itemsForCarouselView(_ view: CarouselView) -> [CarouselItem] {
+        [EmptyItem()]
+            + cameraController.groupIDs.flatMap {
+                cameraController.cameraKit.lenses.repository.lenses(groupID: $0).map {
+                    CarouselItem(lensId: $0.id, groupId: $0.groupId, imageUrl: $0.iconUrl)
+                }
+            }
+    }
+}
+
+// MARK: Camera Button
+import UIKit
+
+extension FlutterCameraViewController: CameraButtonDelegate {
+    public func cameraButtonTapped(_ cameraButton: CameraButton) {
+        print("Camera button tapped")
+        cameraController.takePhoto { image, error in
+            guard let image else { return }
+            
+            let targetSize = CGSize(width: UIScreen.main.bounds.width * 0.5 , height: UIScreen.main.bounds.width * 0.5)
+            let widthScaleRatio = targetSize.width / image.size.width
+            let heightScaleRatio = targetSize.height / image.size.height
+            let scaleFactor = min(widthScaleRatio, heightScaleRatio)
+            let scaledSize = CGSize(
+                width: image.size.width * scaleFactor,
+                height: image.size.height * scaleFactor
+            )
+            
+            let resizedImage = UIGraphicsImageRenderer(size: scaledSize).image {_ in
+                image.draw(in: CGRect(origin: .zero, size: scaledSize))
+            }
+            
+            self.cameraController.clearLens(willReapply: true)
+            let url = URL(fileURLWithPath: "\(NSTemporaryDirectory())\(UUID().uuidString).png")
+            guard let data = resizedImage.jpegData(compressionQuality: 1) ?? image.pngData() else { return }
+            
+            do {
+                try data.write(to: url)
+                self.url = url
+                self.mimeType = "image"
+            } catch {
+                print(error.localizedDescription)
+            }
+            self.onDismiss?()
+            self.dismiss(animated: true)
+        }
+    }
+
+    public func cameraButtonHoldBegan(_ cameraButton: CameraButton) {
+        print("Start recording")
+        cameraController.startRecording()
+        cameraView.hideAllControls()
+        UIView.animate(
+            withDuration: 0.15,
+            animations: { [weak self] in
+                self?.cameraView.cameraActionsView.collapse()
+            }
+        )
+        cameraView.carouselView.hideCarousel()
+        appOrientationDelegate?.lockOrientation(currentInterfaceOrientationMask)
+        cameraView.mediaPickerView.dismiss()
+    }
+
+    public func cameraButtonHoldCancelled(_ cameraButton: CameraButton) {
+        cameraController.cancelRecording()
+        restoreActiveCameraState()
+    }
+
+    public func cameraButtonHoldEnded(_ cameraButton: CameraButton) {
+        print("Finish recording")
+        cameraController.finishRecording { url, error in
+            DispatchQueue.main.async {
+                guard let url else { return }
+                self.url = url
+                self.mimeType = "video"
+                self.cameraController.clearLens(willReapply: true)
+                self.cameraController.restoreBrightnessIfNecessary()
+                self.onDismiss?()
+                self.dismiss(animated: true)
+            }
+        }
+    }
+
+    private func restoreActiveCameraState() {
+        cameraView.cameraActionsView.expand()
+        cameraView.carouselView.showCarousel()
+        appOrientationDelegate?.unlockOrientation()
+    }
+}
+
+// MARK: Ring Light Control Delegate
+
+extension FlutterCameraViewController: FlashControlViewDelegate {
+    public func flashControlView(_ view: FlashControlView, updatedRingLightValue value: Float) {
+        cameraView.ringLightView.ringLightGradient.updateIntensity(to: CGFloat(value), animated: true)
+    }
+
+    public func flashControlView(_ view: FlashControlView, selectedRingLightColor color: UIColor) {
+        cameraView.ringLightView.changeColor(to: color)
+    }
+
+    public func flashControlView(_ view: FlashControlView, updatedFlashMode flashMode: CameraController.FlashMode) {
+        cameraController.flashState = .on(flashMode)
+    }
+}
+
+// MARK: Flash Buttons
+
+extension FlutterCameraViewController {
+    private func setupFlashButtons() {
+        cameraView.cameraActionsView.flashActionView.enableAction = { [weak self] in
+            self?.cameraController.enableFlash()
+        }
+
+        cameraView.cameraActionsView.flashActionView.disableAction = { [weak self] in
+            self?.cameraController.disableFlash()
+        }
+    }
+}
+
+private extension MediaPickerView {
+    func dismiss() {
+        if let provider {
+            mediaPickerProviderRequestedUIDismissal(provider)
+        }
+    }
+}
+
+// MARK: Presentation Delegate
+
+extension FlutterCameraViewController: UIAdaptivePresentationControllerDelegate {
+    open func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
+        guard presentationController.presentedViewController is PreviewViewController else { return }
+        cameraController.reapplyCurrentLens()
+        cameraController.increaseBrightnessIfNecessary()
+    }
+}
+
+// MARK: Agreements presentation context
+
+extension FlutterCameraViewController {
+    class AgreementsPresentationContextProviderImpl: NSObject, AgreementsPresentationContextProvider {
+        weak var cameraViewController: CameraViewController?
+
+        init(cameraViewController: CameraViewController) {
+            self.cameraViewController = cameraViewController
+        }
+
+        public var viewControllerForPresentingAgreements: UIViewController {
+            cameraViewController ?? UIApplication.shared.keyWindow!.rootViewController!
+        }
+
+        public func dismissAgreementsViewController(_ viewController: UIViewController, accepted: Bool) {
+            viewController.dismiss(animated: true, completion: nil)
+            if !accepted {
+                if cameraViewController?.cameraController.currentLens == nil {
+                    cameraViewController?.cameraView.carouselView.selectItem(EmptyItem())
+                }
+            } else {
+                cameraViewController?.cameraView.snapAttributionView.isHidden = false
+            }
+        }
+    }
+}
+
+// MARK: Orientation Helper
+
+private extension FlutterCameraViewController {
+    /// Calculates a user interface orientation based on an input orientation and provided affine transform
+    /// - Parameters:
+    ///   - orientation: the base orientation
+    ///   - transform: the transform specified
+    /// - Returns: the resulting orientation
+    func orientation(from orientation: UIInterfaceOrientation, transform: CGAffineTransform)
+        -> UIInterfaceOrientation
+    {
+        let conversionMatrix: [UIInterfaceOrientation] = [
+            .portrait, .landscapeLeft, .portraitUpsideDown, .landscapeRight,
+        ]
+        guard let oldIndex = conversionMatrix.firstIndex(of: orientation), oldIndex != NSNotFound else {
+            return .unknown
+        }
+        let rotationAngle = atan2(transform.b, transform.a)
+        var newIndex = Int(oldIndex) - Int(round(rotationAngle / (.pi / 2)))
+        while newIndex >= 4 {
+            newIndex -= 4
+        }
+        while newIndex < 0 {
+            newIndex += 4
+        }
+        return conversionMatrix[newIndex]
+    }
+
+    /// Determines the applicable AVCaptureVideoOrientation from a given UIInterfaceOrientation
+    /// - Parameter interfaceOrientation: the interface orientation
+    /// - Returns: the relevant AVCaptureVideoOrientation
+    func videoOrientation(from interfaceOrientation: UIInterfaceOrientation) -> AVCaptureVideoOrientation {
+        switch interfaceOrientation {
+        case .portrait, .unknown: return .portrait
+        case .landscapeLeft: return .landscapeLeft
+        case .landscapeRight: return .landscapeRight
+        case .portraitUpsideDown: return .portraitUpsideDown
+        @unknown default: return .portrait
+        }
+    }
+}

--- a/flutter_frontend/ios/Runner/Info.plist
+++ b/flutter_frontend/ios/Runner/Info.plist
@@ -26,12 +26,16 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSCameraUsageDescription</key>
-	<string>The app needs access to your camera for meetings.</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>The app needs access to your microphone for meetings.</string>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>NSCameraUsageDescription</key>
+        <string>The app needs access to your camera for meetings.</string>
+        <key>NSMicrophoneUsageDescription</key>
+        <string>The app needs access to your microphone for meetings.</string>
+        <key>NSPhotoLibraryUsageDescription</key>
+        <string>Messngr needs access to your photo library to import and store Camera Kit captures.</string>
+        <key>NSPhotoLibraryAddUsageDescription</key>
+        <string>Messngr saves photos and videos from Camera Kit to your library when requested.</string>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
 
     <key>CFBundleTypeRole</key>
     <string>Editor</string>

--- a/flutter_frontend/ios/Runner/SnapCameraKitBridge.swift
+++ b/flutter_frontend/ios/Runner/SnapCameraKitBridge.swift
@@ -1,0 +1,58 @@
+import Flutter
+import Foundation
+import SCSDKCameraKit
+import SCSDKCameraKitReferenceUI
+import UIKit
+
+struct SnapCameraKitConfiguration {
+    let applicationId: String
+    let apiToken: String
+    let lensGroupIds: [String]
+
+    init?(arguments: Any?) {
+        guard let payload = arguments as? [String: Any] else { return nil }
+        guard let apiToken = payload["apiToken"] as? String, !apiToken.isEmpty else { return nil }
+        guard let applicationId = payload["applicationId"] as? String else { return nil }
+        guard let lensGroupIds = payload["lensGroupIds"] as? [String], !lensGroupIds.isEmpty else { return nil }
+
+        self.apiToken = apiToken
+        self.applicationId = applicationId
+        self.lensGroupIds = lensGroupIds
+    }
+}
+
+enum SnapCameraKitBridge {
+    static func present(
+        from controller: FlutterViewController,
+        configuration: SnapCameraKitConfiguration,
+        result: @escaping FlutterResult,
+        cancellation: @escaping () -> Void
+    ) {
+        let cameraController = CameraController(
+            sessionConfig: SessionConfig(applicationID: configuration.applicationId, apiToken: configuration.apiToken)
+        )
+        cameraController.groupIDs = configuration.lensGroupIds
+
+        let cameraViewController = FlutterCameraViewController(cameraController: cameraController)
+        cameraViewController.modalPresentationStyle = .fullScreen
+
+        cameraViewController.onDismiss = {
+            guard let path = cameraViewController.url?.path,
+                  let mimeType = cameraViewController.mimeType else {
+                cancellation()
+                return
+            }
+            result(["path": path, "mime_type": mimeType])
+        }
+
+        cameraViewController.appOrientationDelegate = controller.appDelegate
+
+        controller.present(cameraViewController, animated: false)
+    }
+}
+
+private extension FlutterViewController {
+    var appDelegate: AppOrientationDelegate? {
+        UIApplication.shared.delegate as? AppOrientationDelegate
+    }
+}

--- a/flutter_frontend/lib/config/camera_kit_environment.dart
+++ b/flutter_frontend/lib/config/camera_kit_environment.dart
@@ -1,0 +1,110 @@
+import 'dart:io';
+
+/// Provides runtime configuration for the Snapchat Camera Kit integration.
+class CameraKitEnvironment {
+  CameraKitEnvironment._()
+      : _default = _CameraKitValues(
+          enabled:
+              const bool.fromEnvironment('MSGR_CAMERA_KIT_ENABLED', defaultValue: false),
+          applicationId: const String.fromEnvironment(
+            'MSGR_CAMERA_KIT_APPLICATION_ID',
+            defaultValue: '',
+          ),
+          apiToken: const String.fromEnvironment(
+            'MSGR_CAMERA_KIT_API_TOKEN',
+            defaultValue: '',
+          ),
+          lensGroupIds: _parseLensGroups(
+            const String.fromEnvironment(
+              'MSGR_CAMERA_KIT_LENS_GROUP_IDS',
+              defaultValue: '',
+            ),
+          ),
+        );
+
+  /// Singleton instance that should be used across the app.
+  static final CameraKitEnvironment instance = CameraKitEnvironment._();
+
+  final _CameraKitValues _default;
+  _CameraKitValues? _override;
+
+  /// Whether the integration is explicitly enabled.
+  bool get enabled => (_override ?? _default).enabled;
+
+  /// Application identifier provided by Snapchat for Camera Kit (iOS only).
+  String get applicationId => (_override ?? _default).applicationId;
+
+  /// API token provided by Snapchat for Camera Kit.
+  String get apiToken => (_override ?? _default).apiToken;
+
+  /// Lens group identifiers that should be made available in the picker.
+  List<String> get lensGroupIds => (_override ?? _default).lensGroupIds;
+
+  /// True when the integration has enough configuration to be invoked.
+  bool get isConfigured {
+    if (!enabled) return false;
+    if (apiToken.isEmpty) return false;
+    if (lensGroupIds.isEmpty) return false;
+    if (_isIOS && applicationId.isEmpty) return false;
+    return true;
+  }
+
+  /// Allows changing configuration at runtime – primarily for tests or debug tools.
+  void override({
+    bool? enabled,
+    String? applicationId,
+    String? apiToken,
+    List<String>? lensGroupIds,
+  }) {
+    final source = _override ?? _default;
+    _override = source.copyWith(
+      enabled: enabled,
+      applicationId: applicationId,
+      apiToken: apiToken,
+      lensGroupIds: lensGroupIds,
+    );
+  }
+
+  /// Removes any runtime overrides so subsequent reads use compile-time values.
+  void clearOverride() {
+    _override = null;
+  }
+
+  static List<String> _parseLensGroups(String value) {
+    return value
+        .split(',')
+        .map((raw) => raw.trim())
+        .where((element) => element.isNotEmpty)
+        .toList(growable: false);
+  }
+
+  static bool get _isIOS => Platform.isIOS;
+}
+
+class _CameraKitValues {
+  const _CameraKitValues({
+    required this.enabled,
+    required this.applicationId,
+    required this.apiToken,
+    required this.lensGroupIds,
+  });
+
+  final bool enabled;
+  final String applicationId;
+  final String apiToken;
+  final List<String> lensGroupIds;
+
+  _CameraKitValues copyWith({
+    bool? enabled,
+    String? applicationId,
+    String? apiToken,
+    List<String>? lensGroupIds,
+  }) {
+    return _CameraKitValues(
+      enabled: enabled ?? this.enabled,
+      applicationId: applicationId ?? this.applicationId,
+      apiToken: apiToken ?? this.apiToken,
+      lensGroupIds: lensGroupIds ?? this.lensGroupIds,
+    );
+  }
+}

--- a/flutter_frontend/lib/features/chat/media/chat_media_controller.dart
+++ b/flutter_frontend/lib/features/chat/media/chat_media_controller.dart
@@ -3,11 +3,13 @@ import 'package:image_picker/image_picker.dart';
 
 import 'chat_media_attachment.dart';
 import 'chat_media_picker.dart';
+import '../../../services/camera_kit/snap_camera_kit_media_picker.dart';
 
 /// Coordinates selection and lifecycle of pending chat media attachments.
 class ChatMediaController extends ChangeNotifier {
   ChatMediaController({ChatMediaPicker? picker})
-      : _picker = picker ?? DefaultChatMediaPicker();
+      : _picker =
+            picker ?? SnapCameraKitMediaPicker(fallback: DefaultChatMediaPicker());
 
   final ChatMediaPicker _picker;
   final List<ChatMediaAttachment> _attachments = [];

--- a/flutter_frontend/lib/services/camera_kit/snap_camera_kit.dart
+++ b/flutter_frontend/lib/services/camera_kit/snap_camera_kit.dart
@@ -1,0 +1,120 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Defines the contract that the chat media picker expects for interacting with
+/// Snapchat Camera Kit.
+abstract class SnapCameraKitClient {
+  Future<bool> isSupported();
+
+  Future<SnapCameraKitResult?> launchCapture(SnapCameraKitRequest request);
+}
+
+/// Implementation of [SnapCameraKitClient] backed by a [MethodChannel].
+class SnapCameraKit implements SnapCameraKitClient {
+  SnapCameraKit({MethodChannel? channel})
+      : _channel = channel ?? const MethodChannel(_channelName);
+
+  static const String _channelName = 'dev.meeh.messngr/snap_camera_kit';
+  static const String _methodIsSupported = 'isSupported';
+  static const String _methodLaunch = 'openCameraKit';
+
+  final MethodChannel _channel;
+
+  @override
+  Future<bool> isSupported() async {
+    if (!(Platform.isAndroid || Platform.isIOS)) {
+      return false;
+    }
+
+    try {
+      final supported = await _channel.invokeMethod<bool>(_methodIsSupported);
+      return supported ?? false;
+    } on MissingPluginException {
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  @override
+  Future<SnapCameraKitResult?> launchCapture(
+    SnapCameraKitRequest request,
+  ) async {
+    final payload = <String, dynamic>{
+      'apiToken': request.apiToken,
+      'applicationId': request.applicationId,
+      'lensGroupIds': request.lensGroupIds,
+    };
+
+    try {
+      final response =
+          await _channel.invokeMapMethod<String, dynamic>(_methodLaunch, payload);
+      if (response == null) {
+        return null;
+      }
+
+      final path = response['path'] as String?;
+      final mimeType = response['mime_type'] as String?;
+      if (path == null || mimeType == null) {
+        throw const SnapCameraKitException('Malformed response from Camera Kit');
+      }
+      return SnapCameraKitResult(path: path, mimeType: mimeType);
+    } on MissingPluginException {
+      return null;
+    } on PlatformException catch (error) {
+      if (_isCancellation(error)) {
+        return null;
+      }
+      throw SnapCameraKitException(error.message ?? 'Unknown Camera Kit error');
+    }
+  }
+
+  bool _isCancellation(PlatformException error) {
+    return error.code.toLowerCase() == 'cancelled';
+  }
+}
+
+/// Encapsulates the configuration needed to open Camera Kit on the platform
+/// layers.
+@immutable
+class SnapCameraKitRequest {
+  const SnapCameraKitRequest({
+    required this.apiToken,
+    required this.applicationId,
+    required this.lensGroupIds,
+  });
+
+  final String apiToken;
+  final String applicationId;
+  final List<String> lensGroupIds;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'apiToken': apiToken,
+        'applicationId': applicationId,
+        'lensGroupIds': lensGroupIds,
+      };
+}
+
+/// Result returned when the user successfully captured a photo or video using
+/// Camera Kit.
+@immutable
+class SnapCameraKitResult {
+  const SnapCameraKitResult({
+    required this.path,
+    required this.mimeType,
+  });
+
+  final String path;
+  final String mimeType;
+}
+
+class SnapCameraKitException implements Exception {
+  const SnapCameraKitException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'SnapCameraKitException($message)';
+}

--- a/flutter_frontend/lib/services/camera_kit/snap_camera_kit_media_picker.dart
+++ b/flutter_frontend/lib/services/camera_kit/snap_camera_kit_media_picker.dart
@@ -1,0 +1,72 @@
+import 'package:image_picker/image_picker.dart';
+
+import '../../config/camera_kit_environment.dart';
+import '../../features/chat/media/chat_media_attachment.dart';
+import '../../features/chat/media/chat_media_picker.dart';
+import 'snap_camera_kit.dart';
+
+/// [ChatMediaPicker] implementation that delegates camera capture to Snapchat
+/// Camera Kit when it is configured and supported on the current platform.
+class SnapCameraKitMediaPicker implements ChatMediaPicker {
+  SnapCameraKitMediaPicker({
+    CameraKitEnvironment? environment,
+    SnapCameraKitClient? cameraKit,
+    ChatMediaPicker? fallback,
+  })  : _environment = environment ?? CameraKitEnvironment.instance,
+        _cameraKit = cameraKit ?? SnapCameraKit(),
+        _fallback = fallback ?? DefaultChatMediaPicker();
+
+  final CameraKitEnvironment _environment;
+  final SnapCameraKitClient _cameraKit;
+  final ChatMediaPicker _fallback;
+
+  @override
+  Future<List<ChatMediaAttachment>> pickFromCamera() async {
+    if (!_environment.isConfigured) {
+      return _fallback.pickFromCamera();
+    }
+
+    final supported = await _cameraKit.isSupported();
+    if (!supported) {
+      return _fallback.pickFromCamera();
+    }
+
+    try {
+      final result = await _cameraKit.launchCapture(
+        SnapCameraKitRequest(
+          apiToken: _environment.apiToken,
+          applicationId: _environment.applicationId,
+          lensGroupIds: _environment.lensGroupIds,
+        ),
+      );
+
+      if (result == null) {
+        return const [];
+      }
+
+      final file = XFile(
+        result.path,
+        mimeType: result.mimeType,
+      );
+      final attachment = await ChatMediaAttachment.fromXFile(file);
+      return [attachment];
+    } on SnapCameraKitException {
+      return _fallback.pickFromCamera();
+    }
+  }
+
+  @override
+  Future<List<ChatMediaAttachment>> pickFromGallery() {
+    return _fallback.pickFromGallery();
+  }
+
+  @override
+  Future<List<ChatMediaAttachment>> pickFromFiles() {
+    return _fallback.pickFromFiles();
+  }
+
+  @override
+  Future<List<ChatMediaAttachment>> pickAudio({bool voiceMemo = false}) {
+    return _fallback.pickAudio(voiceMemo: voiceMemo);
+  }
+}

--- a/flutter_frontend/test/services/camera_kit/camera_kit_environment_test.dart
+++ b/flutter_frontend/test/services/camera_kit/camera_kit_environment_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:messngr/config/camera_kit_environment.dart';
+
+void main() {
+  tearDown(() {
+    CameraKitEnvironment.instance.clearOverride();
+  });
+
+  test('isConfigured returns false when integration is disabled', () {
+    CameraKitEnvironment.instance.override(
+      enabled: false,
+      apiToken: 'token',
+      applicationId: 'app',
+      lensGroupIds: const ['group'],
+    );
+
+    expect(CameraKitEnvironment.instance.isConfigured, isFalse);
+  });
+
+  test('isConfigured requires token and lens groups', () {
+    CameraKitEnvironment.instance.override(enabled: true);
+    expect(CameraKitEnvironment.instance.isConfigured, isFalse);
+
+    CameraKitEnvironment.instance.override(
+      enabled: true,
+      apiToken: 'token',
+      lensGroupIds: const [],
+    );
+    expect(CameraKitEnvironment.instance.isConfigured, isFalse);
+  });
+
+  test('isConfigured succeeds with minimal configuration', () {
+    CameraKitEnvironment.instance.override(
+      enabled: true,
+      apiToken: 'token',
+      applicationId: 'app',
+      lensGroupIds: const ['group-a', 'group-b'],
+    );
+
+    expect(CameraKitEnvironment.instance.isConfigured, isTrue);
+    expect(CameraKitEnvironment.instance.lensGroupIds, ['group-a', 'group-b']);
+  });
+
+}

--- a/flutter_frontend/test/services/camera_kit/snap_camera_kit_media_picker_test.dart
+++ b/flutter_frontend/test/services/camera_kit/snap_camera_kit_media_picker_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:messngr/config/camera_kit_environment.dart';
+import 'package:messngr/features/chat/media/chat_media_attachment.dart';
+import 'package:messngr/features/chat/media/chat_media_picker.dart';
+import 'package:messngr/services/camera_kit/snap_camera_kit.dart';
+import 'package:messngr/services/camera_kit/snap_camera_kit_media_picker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeCameraKit cameraKit;
+  late FakeChatMediaPicker fallback;
+
+  setUp(() {
+    cameraKit = FakeCameraKit();
+    fallback = FakeChatMediaPicker();
+    CameraKitEnvironment.instance.clearOverride();
+  });
+
+  tearDown(() {
+    CameraKitEnvironment.instance.clearOverride();
+  });
+
+  test('falls back to default picker when not configured', () async {
+    final picker = SnapCameraKitMediaPicker(
+      cameraKit: cameraKit,
+      fallback: fallback,
+    );
+
+    final attachments = await picker.pickFromCamera();
+
+    expect(attachments, fallback.attachments);
+    expect(fallback.pickFromCameraCount, 1);
+  });
+
+  test('uses Camera Kit when supported and configured', () async {
+    final file = await _createTemporaryFile('camera-kit-test.mp4');
+    cameraKit
+      ..supported = true
+      ..result = SnapCameraKitResult(path: file.path, mimeType: 'video/mp4');
+
+    CameraKitEnvironment.instance.override(
+      enabled: true,
+      apiToken: 'token',
+      applicationId: 'app',
+      lensGroupIds: const ['group'],
+    );
+
+    final picker = SnapCameraKitMediaPicker(
+      cameraKit: cameraKit,
+      fallback: fallback,
+    );
+
+    final attachments = await picker.pickFromCamera();
+
+    expect(fallback.pickFromCameraCount, 0);
+    expect(attachments, hasLength(1));
+    expect(attachments.first.mimeType, 'video/mp4');
+  });
+
+  test('falls back when Camera Kit throws', () async {
+    cameraKit
+      ..supported = true
+      ..shouldThrow = true;
+
+    CameraKitEnvironment.instance.override(
+      enabled: true,
+      apiToken: 'token',
+      applicationId: 'app',
+      lensGroupIds: const ['group'],
+    );
+
+    final picker = SnapCameraKitMediaPicker(
+      cameraKit: cameraKit,
+      fallback: fallback,
+    );
+
+    final attachments = await picker.pickFromCamera();
+
+    expect(fallback.pickFromCameraCount, 1);
+    expect(attachments, fallback.attachments);
+  });
+}
+
+Future<File> _createTemporaryFile(String name) async {
+  final directory = await Directory.systemTemp.createTemp('camera-kit');
+  final file = File('${directory.path}/$name');
+  await file.writeAsBytes(Uint8List.fromList(List<int>.generate(16, (index) => index)));
+  return file;
+}
+
+class FakeCameraKit implements SnapCameraKitClient {
+  bool supported = false;
+  bool shouldThrow = false;
+  SnapCameraKitResult? result;
+
+  @override
+  Future<bool> isSupported() async => supported;
+
+  @override
+  Future<SnapCameraKitResult?> launchCapture(SnapCameraKitRequest request) async {
+    if (shouldThrow) {
+      throw const SnapCameraKitException('boom');
+    }
+    return result;
+  }
+}
+
+class FakeChatMediaPicker implements ChatMediaPicker {
+  FakeChatMediaPicker()
+      : attachments = [
+          ChatMediaAttachment(
+            id: 'fallback',
+            type: ChatMediaType.image,
+            fileName: 'fallback.jpg',
+            mimeType: 'image/jpeg',
+            bytes: Uint8List.fromList(const [0]),
+          ),
+        ];
+
+  final List<ChatMediaAttachment> attachments;
+  int pickFromCameraCount = 0;
+
+  @override
+  Future<List<ChatMediaAttachment>> pickFromCamera() async {
+    pickFromCameraCount += 1;
+    return attachments;
+  }
+
+  @override
+  Future<List<ChatMediaAttachment>> pickFromFiles() async => attachments;
+
+  @override
+  Future<List<ChatMediaAttachment>> pickFromGallery() async => attachments;
+
+  @override
+  Future<List<ChatMediaAttachment>> pickAudio({bool voiceMemo = false}) async => attachments;
+}


### PR DESCRIPTION
## Summary
- add a Snapchat Camera Kit-aware media picker and runtime configuration for the Flutter chat composer
- wire up Android and iOS Camera Kit dependencies with method-channel bridges and native permissions
- document the Camera Kit setup flow and add unit tests covering the picker fallback logic

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eacacd4394832296b6211eec811146