### PR TITLE
Add backlog planning docs and WebAuthn login plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,17 @@
   stubs and added a matching socket telemetry broadcaster in `libmsgr` so both
   backend and Flutter can hook into send→ack timelines.
 
+### Produktplanlegging
+
+- Etablerte `docs/product_backlog.md` for å samle integrasjoner, kanalinitiativer,
+  admin/workspace-forbedringer og P2P/SRTP-satsinger med statusfelt som oppdateres
+  når eksperimenter starter eller avsluttes.
+- Opprettet `docs/webauthn_login_plan.md` med arkitektur for WebAuthn/passkey-
+  innlogginger, IDP-redirects og websocket-push av «login fullført»-signaler fra
+  backend til klient.
+- Triagerte nøkkelidéer i `IDEAS.md` og markerte hvilke eksperimenter som er i
+  discovery samt om de krever frontend- og/eller backend-arbeid.
+
 ### Continuous integration
 
 - La til `Messngr.Metrics.Pipeline` med Telemetry-handlere, reporter-grensesnitt

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,5 +1,16 @@
 # IDEAs
 
+## Eksperimentstatus
+
+| Idé | Scope | Status | Frontend? | Backend? | Notater |
+| --- | --- | --- | --- | --- | --- |
+| Pay-per-feature aktivering | Økosystem/prising | Discovery (2025-05-09) | Nei | Ja | Krever abonnementshåndtering, feature-flags og fakturering via backend. |
+| Passkeys for pålogging | Autentisering | Discovery (2025-05-09) | Ja | Ja | Avhenger av WebAuthn-planen, Flutter-passkey-SDK og nye autentiseringsendepunkt. |
+| QR-koder for familie/workspace-invitasjoner | Onboarding/deling | Backlog | Ja | Ja | Trenger QR-rendering i klienten og signerte invite-tokens i backend. |
+| Quiz/Vote meldingsformat | Meldinger/engasjement | Discovery (2025-05-09) | Ja | Ja | Frontend trenger komponenter for stemmegivning, backend må samle stemmer og emitte resultater. |
+
+Statusfeltet skal oppdateres når eksperimenter starter eller ferdigstilles. Se `CHANGELOG.md` for historikk.
+
 ## General
 
 * Hva med pay per feature?

--- a/docs/product_backlog.md
+++ b/docs/product_backlog.md
@@ -1,0 +1,35 @@
+# Produktbacklogg
+
+Denne backloggen grupperer de mest etterspurte satsingene slik at integrasjoner og kjernefunksjoner kan planlegges koordinert.
+
+## Integrasjoner
+
+| Initiativ | Mål | Status | Avhengigheter |
+| --- | --- | --- | --- |
+| Slack bridge alfa | Fullføre resterende «remaining work»-liste og pilotere sanntidsflyt | Pågående | `docs/slack_bridge_remaining_work.md`, bridge-daemons |
+| Microsoft Teams bridge | Levere webhook-/poller-paritet og admin-opplevelser | Pågående | `docs/teams_bridge_remaining_work.md`, Graph API |
+| WhatsApp utforskning | Kartlegge uoffisielle API-er og kostnadsprofil | Backlog | Reverse engineering, potensielle tredjeparts-SDK-er |
+
+## Kanaler
+
+| Initiativ | Mål | Status | Avhengigheter |
+| --- | --- | --- | --- |
+| Nyhetskanaler (RSS) | Automatisk innhold for å aktivere tomme spaces | Backlog | Feed-aggregator, kanal-administrasjon |
+| Familie/vennekanaler | Kuratere standardmaler og invitasjonsflyt | Backlog | QR-/invitasjonsflyt, workspace-tema |
+
+## Admin og Workspace
+
+| Initiativ | Mål | Status | Avhengigheter |
+| --- | --- | --- | --- |
+| Pay-per-feature modell | Utforske modulbasert fakturering og feature gating | Discovery | Billing backends, feature toggles |
+| Workspace onboarding | Forenkle oppsett for nye admins inkl. maler | Backlog | Admin UI, dokumentasjon |
+| Passkey-styrt innlogging | Aktivere WebAuthn i alle klienter | Discovery | Se `docs/webauthn_login_plan.md` |
+
+## P2P / SRTP
+
+| Initiativ | Mål | Status | Avhengigheter |
+| --- | --- | --- | --- |
+| WebRTC-video | P2P-samtaler med fallback til relé | Backlog | TURN-infrastruktur, klientkode |
+| SRTP-hardening | Definere nøkkelbytte og codecs for sikre samtaler | Backlog | Noise/DTLS integrasjon, medieservere |
+
+Backloggen bør revideres når nye eksperimenter startes eller ferdigstilles slik at statuslinjene reflekterer den delte forståelsen.

--- a/docs/webauthn_login_plan.md
+++ b/docs/webauthn_login_plan.md
@@ -1,0 +1,52 @@
+# WebAuthn og IDP-innlogging
+
+Denne planen beskriver hvordan Msgr skal støtte passkey-baserte WebAuthn-innlogginger og eksterne IDP-strømmer der brukeren fullfører autentisering i nettleser før appen får beskjed.
+
+## Mål
+
+1. Støtte native WebAuthn-passkeys i Flutter-klienten.
+2. La backend orkestrere passkey-registrering og -innlogging via Noise/OAuth-endepunkt.
+3. Håndtere IDP-redirect (Google, Azure AD m.fl.) der brukeren logger inn i ekstern nettleser.
+4. Pushe «login fullført»-signal fra backend til appen uten at brukeren manuelt fornyer token.
+
+## Arkitektur
+
+### 1. Session Broker
+
+* Opprett nytt backend-endepunkt `POST /api/auth/external/sessions` som utsteder en kortlivet `session_token` og metadata om forventet autentiseringsmetode (webauthn/idp).
+* Lagre sessioner i en `external_login_sessions` tabell med status (`pending`, `approved`, `failed`) og opsjonelt `public_key_credential_request` payload for WebAuthn.
+* Flutter initialiserer en `ExternalLoginSession` gjennom Auth store og starter WebAuthn- eller IDP-flyt basert på type.
+
+### 2. WebAuthn-håndtering
+
+* Backend bruker `webauthn_ex` (Elixir) til å generere `PublicKeyCredentialCreationOptions` for registrering og `...RequestOptions` for innlogging.
+* Flutter bruker `corbado/flutter-passkeys` (se IDEAS) for å hente `AuthenticatorResponse` og poster til `POST /api/auth/external/webauthn/callback`.
+* Callback validerer respons, oppdaterer session status til `approved` og utsteder Noise token + refresh token.
+
+### 3. IDP-redirect
+
+* Session broker returnerer `verification_uri` og `session_token`.
+* Appen åpner nettleser med `verification_uri?session_token=...` for OAuth/OIDC.
+* Etter vellykket IDP-login treffer redirect en ny `ExternalAuthController.callback/2` som validerer koden, knytter IDP-identitet til bruker og markerer session `approved`.
+
+### 4. Server push til app
+
+* Introducer et nytt Phoenix Channel (`external_sessions`) eller gjenbruk eksisterende socket med topic `external_session:<session_token>`.
+* Når session status endres, broadcaster backend et `session_update` event med `status` og eventuelle tokens.
+* Flutter abonnerer på topic umiddelbart etter at session er opprettet. Når `approved` mottas, lukker den nettleseren (hvis fortsatt åpen) og fullfører innlogging ved å lagre Noise/refresh tokens.
+* For enheter uten websockets, fallback til `GET /api/auth/external/sessions/:token` polling hver 2. sekund.
+
+### 5. Sikkerhet og UX
+
+* Sessions utløper etter 5 minutter og blir automatisk `failed`.
+* Push-event inkluderer `mfa_required` flagg hvis ytterligere steg kreves.
+* Logging og metrikker: emit `external_login.session_created`, `...completed`, `...expired` for observability.
+
+## Milepæler
+
+1. **Discovery (aktiv)** – valider Flutter-passkey-APIer og bibliotekvalg, definér databaseoppsett.
+2. **Prototype** – implementere session broker + websocket broadcast uten IDP/WAF hardening.
+3. **Pilot** – støtte Google og Azure AD, skrive ende-til-ende tester.
+4. **Generell tilgjengelighet** – dokumentasjon, feilhåndtering og fallback.
+
+Status spyles inn i `IDEAS.md` (eksperimenttabellen) og `CHANGELOG.md` når milepæler beveger seg fremover.


### PR DESCRIPTION
## Summary
- add a product backlog document that groups integrations, channel initiatives, workspace administration, and P2P/SRTP tracks
- document the WebAuthn/IDP login plan including external session broker and server push flow
- triage key ideas with backend/frontend ownership flags and discovery status while recording the update in the changelog

## Testing
- mix test *(fails: mix is unavailable in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f045a1108083228d85d3df6e9aa2c0