### PR TITLE
Add durable outgoing message queue and retry handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,9 @@
 - Hardened media signing by requiring environment-provided secrets, binding
   checksums into presigned URLs, and covering the behaviour with tests and
   updated operator docs so alpha deployments can trust object storage links.
+- Added a durable Flutter websocket outgoing message queue that persists
+  unsent/ack-pending messages, retries with backoff on reconnect, and clears
+  entries once delivery is confirmed.
 - Enforced Noise handshake verification by default, removed legacy header fallbacks,
   and wired OTP challenges to rate limiting plus email/SMS delivery so passwordless
   auth is safe to expose to alpha testers.

--- a/flutter_frontend/lib/redux/message/message_middleware.dart
+++ b/flutter_frontend/lib/redux/message/message_middleware.dart
@@ -23,7 +23,7 @@ void Function(
       final repos = LibMsgr()
           .repositoryFactory
           .getRepositories(store.state.authState.currentTeamName!);
-      final push = repos.messageRepository.sendMessageToRoom(action.msg);
+      final push = await repos.messageRepository.sendMessageToRoom(action.msg);
       if (push == null) {
         const error = 'Failed to enqueue message.';
         action.completer.completeError(error);

--- a/flutter_frontend/packages/libmsgr/CHANGELOG.md
+++ b/flutter_frontend/packages/libmsgr/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Removed the deprecated `tool/msgr_cli.dart` forwarder now that the standalone
   `libmsgr_cli` package is used directly.
+- Added a durable outgoing message queue with persisted retries/backoff and
+  acknowledgement cleanup for websocket sends.
 
 ## 0.1.2
 

--- a/flutter_frontend/packages/libmsgr/lib/libmsgr.dart
+++ b/flutter_frontend/packages/libmsgr/lib/libmsgr.dart
@@ -22,6 +22,7 @@ export 'src/models/team.dart';
 export 'src/models/room.dart';
 export 'src/models/conversation.dart';
 export 'src/models/message.dart';
+export 'src/models/outgoing_message.dart';
 export 'src/models/auth_challenge.dart';
 
 export 'src/registration_service.dart';

--- a/flutter_frontend/packages/libmsgr/lib/src/connection.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/connection.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:libmsgr/libmsgr.dart';
 import 'package:libmsgr/src/telemetry/socket_telemetry.dart';
 import 'package:libmsgr/src/typedefs.dart';
@@ -68,11 +70,15 @@ class MsgrConnection {
     userChannel = joinChannel('user:$userID');
     _presence = PhoenixPresence(channel: userChannel);
     _presence.onSync = presenceOnSync;
+    final repos = LibMsgr().repositoryFactory.getRepositories(tenant);
+    await repos.messageRepository.onConnectionChanged(isConnected: true);
   }
 
   void _handleDisconnect(event) {
     _log.info('[-] Socket disconnected! event: ${event.toString()}');
     _connected = false;
+    final repos = LibMsgr().repositoryFactory.getRepositories(tenant);
+    unawaited(repos.messageRepository.onConnectionChanged(isConnected: false));
   }
 
   List<Room> _handleRoomsPacket(

--- a/flutter_frontend/packages/libmsgr/lib/src/database/constants.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/database/constants.dart
@@ -19,3 +19,4 @@ const omemoTrustTable = 'OmemoTrustTable';
 const notificationsTable = 'Notifications';
 const groupchatTable = 'Groupchat';
 const groupchatMembersTable = 'GroupchatMembers';
+const outgoingMessagesTable = 'OutgoingMessages';

--- a/flutter_frontend/packages/libmsgr/lib/src/database/creation.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/database/creation.dart
@@ -87,4 +87,21 @@ Future<void> createDatabase(Database db, int version) async {
   await db.execute(
     'CREATE INDEX messages_profile_idx ON $messagesTable(team_name, profile_id)',
   );
+
+  await db.execute(
+    '''
+    CREATE TABLE $outgoingMessagesTable (
+      message_id TEXT NOT NULL,
+      team_name TEXT NOT NULL,
+      topic TEXT NOT NULL,
+      payload TEXT NOT NULL,
+      last_attempt_at TEXT,
+      attempt_count INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (message_id, team_name)
+    )''',
+  );
+
+  await db.execute(
+    'CREATE INDEX outgoing_messages_team_idx ON $outgoingMessagesTable(team_name)',
+  );
 }

--- a/flutter_frontend/packages/libmsgr/lib/src/database/daos/outgoing_message_dao.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/database/daos/outgoing_message_dao.dart
@@ -1,0 +1,53 @@
+import 'package:libmsgr/src/database/constants.dart';
+import 'package:libmsgr/src/models/outgoing_message.dart';
+import 'package:sqflite_sqlcipher/sqflite.dart';
+
+class OutgoingMessageDao {
+  const OutgoingMessageDao(this._db);
+
+  final Database _db;
+
+  Future<void> enqueue(String teamName, OutgoingMessage entry) async {
+    await _db.insert(
+      outgoingMessagesTable,
+      entry.toDbMap(teamName),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<void> markAttempt(
+    String teamName,
+    String messageId, {
+    required DateTime attemptedAt,
+    required int attemptCount,
+  }) async {
+    await _db.update(
+      outgoingMessagesTable,
+      <String, Object?>{
+        'last_attempt_at': attemptedAt.toIso8601String(),
+        'attempt_count': attemptCount,
+      },
+      where: 'message_id = ? AND team_name = ?',
+      whereArgs: [messageId, teamName],
+    );
+  }
+
+  Future<void> delete(String teamName, String messageId) async {
+    await _db.delete(
+      outgoingMessagesTable,
+      where: 'message_id = ? AND team_name = ?',
+      whereArgs: [messageId, teamName],
+    );
+  }
+
+  Future<List<OutgoingMessage>> getPending(String teamName) async {
+    final rows = await _db.query(
+      outgoingMessagesTable,
+      where: 'team_name = ?',
+      whereArgs: [teamName],
+      orderBy: 'last_attempt_at IS NOT NULL, last_attempt_at ASC',
+    );
+
+    return rows.map(OutgoingMessage.fromDbMap).toList(growable: false);
+  }
+}

--- a/flutter_frontend/packages/libmsgr/lib/src/database/database.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/database/database.dart
@@ -3,6 +3,7 @@ import 'package:libmsgr/src/database/migration.dart';
 import 'package:libmsgr/src/database/migrations/000_initial_migration.dart';
 import 'package:libmsgr/src/database/migrations/001_add_messages_and_contacts.dart';
 import 'package:libmsgr/src/database/migrations/002_profile_preferences.dart';
+import 'package:libmsgr/src/database/migrations/003_outgoing_message_queue.dart';
 import 'package:logging/logging.dart';
 import 'package:sqflite_common/src/sql_builder.dart';
 import 'package:sqflite_sqlcipher/sqflite.dart';
@@ -16,6 +17,7 @@ const List<Migration<DatabaseMigrationData>> migrations = [
   Migration(2, upgradeFromV1ToV2),
   Migration(3, upgradeFromV2ToV3),
   Migration(4, upgradeFromV3ToV4),
+  Migration(5, upgradeFromV4ToV5),
 ];
 
 class DatabaseService {

--- a/flutter_frontend/packages/libmsgr/lib/src/database/migrations/003_outgoing_message_queue.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/database/migrations/003_outgoing_message_queue.dart
@@ -1,0 +1,27 @@
+import 'package:libmsgr/src/database/constants.dart';
+import 'package:libmsgr/src/database/database.dart';
+import 'package:logging/logging.dart';
+import 'package:sqflite_sqlcipher/sqflite.dart';
+
+Future<void> upgradeFromV4ToV5(DatabaseMigrationData data) async {
+  final (Database db, Logger log) = data;
+
+  log.info('Adding $outgoingMessagesTable table for durable outgoing messages');
+
+  await db.execute(
+    '''
+    CREATE TABLE IF NOT EXISTS $outgoingMessagesTable (
+      message_id TEXT NOT NULL,
+      team_name TEXT NOT NULL,
+      topic TEXT NOT NULL,
+      payload TEXT NOT NULL,
+      last_attempt_at TEXT,
+      attempt_count INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (message_id, team_name)
+    )''',
+  );
+
+  await db.execute(
+    'CREATE INDEX IF NOT EXISTS outgoing_messages_team_idx ON $outgoingMessagesTable(team_name)',
+  );
+}

--- a/flutter_frontend/packages/libmsgr/lib/src/models/outgoing_message.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/models/outgoing_message.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+
+import 'package:libmsgr/libmsgr.dart';
+
+/// A durable queue entry for messages waiting on server acknowledgement.
+class OutgoingMessage {
+  const OutgoingMessage({
+    required this.message,
+    required this.topic,
+    this.lastAttemptAt,
+    this.attemptCount = 0,
+  });
+
+  final MMessage message;
+  final String topic;
+  final DateTime? lastAttemptAt;
+  final int attemptCount;
+
+  Map<String, Object?> toDbMap(String teamName) {
+    return <String, Object?>{
+      'message_id': message.id,
+      'team_name': teamName,
+      'topic': topic,
+      'payload': jsonEncode(message.toMap()),
+      'last_attempt_at': lastAttemptAt?.toIso8601String(),
+      'attempt_count': attemptCount,
+    };
+  }
+
+  OutgoingMessage copyWith({
+    MMessage? message,
+    String? topic,
+    DateTime? lastAttemptAt,
+    int? attemptCount,
+  }) {
+    return OutgoingMessage(
+      message: message ?? this.message,
+      topic: topic ?? this.topic,
+      lastAttemptAt: lastAttemptAt ?? this.lastAttemptAt,
+      attemptCount: attemptCount ?? this.attemptCount,
+    );
+  }
+
+  static OutgoingMessage fromDbMap(Map<String, Object?> map) {
+    final payload = jsonDecode(map['payload']! as String) as Map<String, dynamic>;
+
+    return OutgoingMessage(
+      message: MMessage.fromMap(payload),
+      topic: map['topic']! as String,
+      lastAttemptAt: map['last_attempt_at'] == null
+          ? null
+          : DateTime.parse(map['last_attempt_at']! as String),
+      attemptCount: (map['attempt_count']! as num).toInt(),
+    );
+  }
+}

--- a/flutter_frontend/packages/libmsgr/lib/src/repositories/message_repository.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/repositories/message_repository.dart
@@ -1,20 +1,39 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:libmsgr/libmsgr.dart';
 import 'package:libmsgr/src/database/daos/message_dao.dart';
+import 'package:libmsgr/src/database/daos/outgoing_message_dao.dart';
+import 'package:libmsgr/src/models/outgoing_message.dart';
 import 'package:libmsgr/src/repositories/base.dart';
 import 'package:libmsgr/src/typedefs.dart';
 import 'package:phoenix_socket/phoenix_socket.dart';
 
-class MessageRepository extends BaseRepository<MMessage> {
-  final MessagesInTransit _outgoingMessages = [];
-  final MessageDao _dao;
+typedef MsgrConnectionProvider = MsgrConnection? Function();
 
-  MessageRepository({required super.teamName, required MessageDao dao})
-      : _dao = dao {
+class MessageRepository extends BaseRepository<MMessage> {
+  MessageRepository({
+    required super.teamName,
+    required MessageDao dao,
+    OutgoingMessageDao? outgoingMessageDao,
+    MsgrConnectionProvider? connectionProvider,
+  })  : _dao = dao,
+        _outgoingDao = outgoingMessageDao ??
+            OutgoingMessageDao(LibMsgr().databaseService.instance),
+        _connectionProvider = connectionProvider ??
+            () => LibMsgr().getWebsocketConnection() {
     log.info('MessageRepository is starting up.');
     unawaited(_hydrateFromDisk());
   }
+
+  static const Duration _baseBackoff = Duration(seconds: 2);
+  static const int _maxAttempts = 5;
+
+  final MessageDao _dao;
+  final OutgoingMessageDao _outgoingDao;
+  final MsgrConnectionProvider _connectionProvider;
+  Timer? _retryTimer;
+  bool _processingQueue = false;
 
   Future<void> _hydrateFromDisk() async {
     final stored = await _dao.getMessagesForTeam(teamName);
@@ -152,37 +171,134 @@ class MessageRepository extends BaseRepository<MMessage> {
     return listen;
   }
 
-  Push? sendMessageToRoom(MMessage msg) {
-    _outgoingMessages.add(msg);
-    final wsConn = LibMsgr().getWebsocketConnection();
-    Push? p = wsConn?.sendMessage('$teamName.${msg.roomID!}', msg);
-    if (p == null) {
-      log.severe('Error sending message: Push is null');
-      return null;
-    }
-    p.future.then((value) {
-      _outgoingMessages.remove(msg);
-    });
-    p.future.catchError((e) {
-      log.severe('Error sending message: $e');
-    });
-    return p;
+  Future<Push?> sendMessageToRoom(MMessage msg) {
+    return _enqueueAndSend(
+      msg.copyWith(isServerAck: false),
+      '$teamName.${msg.roomID!}',
+    );
   }
 
-  Push? sendMessageToConversation(MMessage msg) {
-    _outgoingMessages.add(msg);
-    final wsConn = LibMsgr().getWebsocketConnection();
-    Push? p = wsConn?.sendMessage('$teamName.${msg.conversationID!}', msg);
-    if (p == null) {
-      log.severe('Error sending message: Push is null');
+  Future<Push?> sendMessageToConversation(MMessage msg) {
+    return _enqueueAndSend(
+      msg.copyWith(isServerAck: false),
+      '$teamName.${msg.conversationID!}',
+    );
+  }
+
+  Future<void> processPendingQueue() async {
+    if (_processingQueue) {
+      return;
+    }
+    _processingQueue = true;
+
+    try {
+      final pending = await _outgoingDao.getPending(teamName);
+
+      if (pending.isEmpty) {
+        _retryTimer?.cancel();
+        _retryTimer = null;
+        return;
+      }
+
+      final now = DateTime.now();
+      Duration? nextAttemptIn;
+
+      for (final entry in pending) {
+        final delay = _backoffFor(entry);
+        final lastAttempt = entry.lastAttemptAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+        final nextAttemptAt = lastAttempt.add(delay);
+
+        if (entry.attemptCount >= _maxAttempts) {
+          log.warning(
+            'Dropping message ${entry.message.id} after $_maxAttempts failed attempts',
+          );
+          await _outgoingDao.delete(teamName, entry.message.id);
+          continue;
+        }
+
+        if (nextAttemptAt.isAfter(now)) {
+          final remaining = nextAttemptAt.difference(now);
+          if (nextAttemptIn == null || remaining < nextAttemptIn) {
+            nextAttemptIn = remaining;
+          }
+          continue;
+        }
+
+        await _sendQueuedMessage(entry);
+      }
+
+      if (nextAttemptIn != null) {
+        _retryTimer?.cancel();
+        _retryTimer = Timer(nextAttemptIn, processPendingQueue);
+      }
+    } finally {
+      _processingQueue = false;
+    }
+  }
+
+  Future<void> onConnectionChanged({required bool isConnected}) async {
+    if (isConnected) {
+      await processPendingQueue();
+    } else {
+      _retryTimer?.cancel();
+      _retryTimer = Timer(_baseBackoff, processPendingQueue);
+    }
+  }
+
+  Future<Push?> _enqueueAndSend(MMessage msg, String topic) async {
+    final entry = OutgoingMessage(message: msg, topic: topic);
+    await _outgoingDao.enqueue(teamName, entry);
+    final push = await _sendQueuedMessage(entry);
+    await processPendingQueue();
+    return push;
+  }
+
+  Future<Push?> _sendQueuedMessage(OutgoingMessage entry) async {
+    final wsConn = _connectionProvider();
+    if (wsConn == null || !wsConn.isConnected()) {
+      log.warning('No active websocket connection; will retry ${entry.message.id}');
+      _scheduleRetry();
       return null;
     }
-    p.future.then((value) {
-      _outgoingMessages.remove(msg);
+
+    final updatedEntry = entry.copyWith(
+      lastAttemptAt: DateTime.now(),
+      attemptCount: entry.attemptCount + 1,
+    );
+    await _outgoingDao.markAttempt(
+      teamName,
+      entry.message.id,
+      attemptedAt: updatedEntry.lastAttemptAt!,
+      attemptCount: updatedEntry.attemptCount,
+    );
+
+    final push = wsConn.sendMessage(entry.topic, entry.message);
+    if (push == null) {
+      log.severe('Error sending message: Push is null');
+      _scheduleRetry();
+      return null;
+    }
+
+    push.future.then((value) async {
+      await _outgoingDao.delete(teamName, entry.message.id);
+    }).catchError((e) async {
+      log.severe('Error sending message ${entry.message.id}: $e');
+      _scheduleRetry();
     });
-    p.future.catchError((e) {
-      log.severe('Error sending message: $e');
-    });
-    return p;
+    return push;
+  }
+
+  Duration _backoffFor(OutgoingMessage entry) {
+    final multiplier = math.pow(2, entry.attemptCount).toInt();
+    final seconds = (_baseBackoff.inSeconds * multiplier).clamp(
+      _baseBackoff.inSeconds,
+      60,
+    );
+    return Duration(seconds: seconds);
+  }
+
+  void _scheduleRetry() {
+    _retryTimer?.cancel();
+    _retryTimer = Timer(_baseBackoff, processPendingQueue);
   }
 }

--- a/flutter_frontend/packages/libmsgr/lib/src/repositories/repository_factory.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/repositories/repository_factory.dart
@@ -1,5 +1,6 @@
 import 'package:libmsgr/src/database/daos/contact_dao.dart';
 import 'package:libmsgr/src/database/daos/message_dao.dart';
+import 'package:libmsgr/src/database/daos/outgoing_message_dao.dart';
 import 'package:libmsgr/src/database/database.dart';
 import 'package:libmsgr/src/typedefs.dart';
 
@@ -35,6 +36,7 @@ class TeamRepositories {
   TeamRepositories(this.teamName, this.database) {
     final db = database.instance;
     final messageDao = MessageDao(db);
+    final outgoingDao = OutgoingMessageDao(db);
     final contactDao = ContactDao(db);
 
     roomRepository = RoomRepository(teamName: teamName);
@@ -42,6 +44,7 @@ class TeamRepositories {
     messageRepository = MessageRepository(
       teamName: teamName,
       dao: messageDao,
+      outgoingMessageDao: outgoingDao,
     );
     profileRepository = ProfileRepository(
       teamName: teamName,

--- a/flutter_frontend/packages/libmsgr/lib/src/typedefs.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/typedefs.dart
@@ -6,7 +6,6 @@ typedef ConversationCacheType = Map<String, Conversation>;
 typedef ConversationList = List<Conversation>;
 
 typedef MessageCacheType = Map<String, List<MMessage>>;
-typedef MessagesInTransit = List<MMessage>;
 typedef MessageList = List<MMessage>;
 
 typedef ProfileCacheType = Map<String, Profile>;

--- a/flutter_frontend/packages/libmsgr/test/database/outgoing_message_dao_test.dart
+++ b/flutter_frontend/packages/libmsgr/test/database/outgoing_message_dao_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libmsgr/libmsgr.dart';
+import 'package:libmsgr/src/database/daos/outgoing_message_dao.dart';
+import 'package:libmsgr/src/database/database.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  group('OutgoingMessageDao', () {
+    late DatabaseService databaseService;
+    late OutgoingMessageDao dao;
+    late MMessage sampleMessage;
+
+    setUp(() async {
+      databaseService = DatabaseService();
+      await databaseService.initialize();
+      dao = OutgoingMessageDao(databaseService.instance);
+      sampleMessage = MMessage.raw(
+        id: 'msg-1',
+        content: 'Hello world',
+        fromProfileID: 'profile-1',
+        conversationID: 'conversation-1',
+        roomID: null,
+        createdAt: DateTime.utc(2024, 1, 1),
+        updatedAt: DateTime.utc(2024, 1, 1, 0, 1),
+        isServerAck: false,
+      );
+    });
+
+    tearDown(() async {
+      final path = databaseService.instance.path;
+      await databaseService.instance.close();
+      await databaseFactory.deleteDatabase(path);
+    });
+
+    test('enqueues and retrieves pending messages', () async {
+      final outgoing = OutgoingMessage(
+        message: sampleMessage,
+        topic: 'team.conversation-1',
+      );
+
+      await dao.enqueue('team-a', outgoing);
+
+      final pending = await dao.getPending('team-a');
+
+      expect(pending, hasLength(1));
+      expect(pending.single.message.id, sampleMessage.id);
+      expect(pending.single.topic, outgoing.topic);
+    });
+
+    test('tracks attempts and deletions', () async {
+      final outgoing = OutgoingMessage(
+        message: sampleMessage,
+        topic: 'team.conversation-1',
+      );
+
+      await dao.enqueue('team-a', outgoing);
+      await dao.markAttempt(
+        'team-a',
+        sampleMessage.id,
+        attemptedAt: DateTime.utc(2024, 2, 1),
+        attemptCount: 2,
+      );
+
+      var pending = await dao.getPending('team-a');
+      expect(pending.single.attemptCount, 2);
+      expect(pending.single.lastAttemptAt, DateTime.utc(2024, 2, 1));
+
+      await dao.delete('team-a', sampleMessage.id);
+      pending = await dao.getPending('team-a');
+      expect(pending, isEmpty);
+    });
+  });
+}

--- a/flutter_frontend/packages/libmsgr/test/repositories/message_repository_test.dart
+++ b/flutter_frontend/packages/libmsgr/test/repositories/message_repository_test.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:libmsgr/libmsgr.dart';
+import 'package:libmsgr/src/database/daos/message_dao.dart';
+import 'package:libmsgr/src/database/daos/outgoing_message_dao.dart';
+import 'package:libmsgr/src/database/database.dart';
+import 'package:libmsgr/src/repositories/message_repository.dart';
+import 'package:mockito/mockito.dart';
+import 'package:phoenix_socket/phoenix_socket.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class MockMsgrConnection extends Mock implements MsgrConnection {}
+
+class MockPush extends Mock implements Push {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  sqfliteFfiInit();
+  databaseFactory = databaseFactoryFfi;
+
+  late DatabaseService databaseService;
+  late MessageDao messageDao;
+  late OutgoingMessageDao outgoingDao;
+  late MessageRepository repository;
+  late MockMsgrConnection connection;
+  late MockPush push;
+  late Completer<dynamic> pushCompleter;
+  var connected = true;
+
+  setUp(() async {
+    databaseService = DatabaseService();
+    await databaseService.initialize();
+    messageDao = MessageDao(databaseService.instance);
+    outgoingDao = OutgoingMessageDao(databaseService.instance);
+    connection = MockMsgrConnection();
+    push = MockPush();
+    pushCompleter = Completer<dynamic>();
+    connected = true;
+
+    when(connection.isConnected()).thenAnswer((_) => connected);
+    when(push.future).thenAnswer((_) => pushCompleter.future);
+    when(connection.sendMessage(any, any)).thenReturn(push);
+
+    repository = MessageRepository(
+      teamName: 'team-a',
+      dao: messageDao,
+      outgoingMessageDao: outgoingDao,
+      connectionProvider: () => connection,
+    );
+  });
+
+  tearDown(() async {
+    final path = databaseService.instance.path;
+    await databaseService.instance.close();
+    await databaseFactory.deleteDatabase(path);
+  });
+
+  MMessage _sampleMessage({String id = 'msg-1', String? roomId, String? conversationId}) {
+    return MMessage.raw(
+      id: id,
+      content: 'Hi',
+      fromProfileID: 'profile-1',
+      conversationID: conversationId,
+      roomID: roomId,
+      createdAt: DateTime.utc(2024, 1, 1),
+      updatedAt: DateTime.utc(2024, 1, 1),
+      isServerAck: false,
+    );
+  }
+
+  test('writes queue entries before sending and clears on ack', () async {
+    final msg = _sampleMessage(roomId: 'room-1');
+
+    await repository.sendMessageToRoom(msg);
+
+    var pending = await outgoingDao.getPending('team-a');
+    expect(pending, hasLength(1));
+
+    pushCompleter.complete({'status': 'ok'});
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    pending = await outgoingDao.getPending('team-a');
+    expect(pending, isEmpty);
+    verify(connection.sendMessage('team-a.room-1', any)).called(1);
+  });
+
+  test('retries pending messages when the connection comes back', () async {
+    connected = false;
+    when(connection.sendMessage(any, any)).thenReturn(null);
+    final msg = _sampleMessage(roomId: 'room-2', id: 'retry-msg');
+
+    await repository.sendMessageToRoom(msg);
+
+    var pending = await outgoingDao.getPending('team-a');
+    expect(pending.single.attemptCount, 0);
+
+    connected = true;
+    when(connection.sendMessage(any, any)).thenReturn(push);
+    pushCompleter = Completer<dynamic>();
+    when(push.future).thenAnswer((_) => pushCompleter.future);
+
+    await repository.processPendingQueue();
+
+    pending = await outgoingDao.getPending('team-a');
+    expect(pending.single.attemptCount, 1);
+
+    pushCompleter.complete({'status': 'ok'});
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    pending = await outgoingDao.getPending('team-a');
+    expect(pending, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add a persistent outgoing message queue with retry metadata and a migration/table to store pending messages
- enqueue outgoing chat sends before socket delivery, retry them with backoff on reconnect, and clear entries after acknowledgements
- cover the new queue DAO and repository behaviour with tests and document the reliability queue in the changelog

## Testing
- Not run (flutter SDK unavailable in container)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ec33995b08322a9831de7ed3566b6)