### PR TITLE
Add delivery status tracking for messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Architecture checklist
 
+- Added delivery status tracking for messages (pending/sending/delivered/failed),
+  persisted in the local database with migration, websocket callbacks, and
+  repository notifications so UIs can show sending/failed indicators.
 - Modellert utvidede profilpreferanser (tema, varsel- og sikkerhetspolicyer) på
   Flutter, eksponerte `ProfileApi` for CRUD/bytte, la til modus-veksler med
   banner/inbox-filtre samt dokumentasjon av scenarier i `docs/profile_modes.md`.

--- a/flutter_frontend/packages/libmsgr/lib/src/connection.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/connection.dart
@@ -190,6 +190,12 @@ class MsgrConnection {
 
       final push = chl.push('create:msg', msg.toMap());
       push?.future.then((response) {
+        final repos = LibMsgr().repositoryFactory.getRepositories(tenant);
+        repos.messageRepository.updateDeliveryStatus(
+          msg.id,
+          MessageDeliveryStatus.delivered,
+          isServerAck: true,
+        );
         SocketTelemetry.instance.messageAcknowledged(
           conversationId: msg.conversationID ?? msg.roomID ?? destID,
           messageId: msg.id,
@@ -199,6 +205,11 @@ class MsgrConnection {
           },
         );
       }).catchError((error) {
+        final repos = LibMsgr().repositoryFactory.getRepositories(tenant);
+        repos.messageRepository.updateDeliveryStatus(
+          msg.id,
+          MessageDeliveryStatus.failed,
+        );
         SocketTelemetry.instance.messageAcknowledged(
           conversationId: msg.conversationID ?? msg.roomID ?? destID,
           messageId: msg.id,

--- a/flutter_frontend/packages/libmsgr/lib/src/database/creation.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/database/creation.dart
@@ -72,6 +72,7 @@ Future<void> createDatabase(Database db, int version) async {
       in_reply_to_id TEXT,
       is_server_ack INTEGER NOT NULL,
       is_msg_read INTEGER NOT NULL,
+      delivery_status TEXT NOT NULL,
       PRIMARY KEY (id, team_name)
     )''',
   );

--- a/flutter_frontend/packages/libmsgr/lib/src/database/daos/message_dao.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/database/daos/message_dao.dart
@@ -98,6 +98,7 @@ class MessageDao {
       'in_reply_to_id': message.inReplyToMsgID,
       'is_server_ack': boolToInt(message.isServerAck),
       'is_msg_read': boolToInt(message.isMsgRead),
+      'delivery_status': message.deliveryStatus.name,
     };
   }
 
@@ -114,6 +115,10 @@ class MessageDao {
       inReplyToMsgID: map['in_reply_to_id'] as String?,
       isServerAck: intToBool(map['is_server_ack']! as int),
       isMsgRead: intToBool(map['is_msg_read']! as int),
+      deliveryStatus: MessageDeliveryStatus.values.firstWhere(
+        (status) => status.name == map['delivery_status']! as String,
+        orElse: () => MessageDeliveryStatus.delivered,
+      ),
     );
   }
 }

--- a/flutter_frontend/packages/libmsgr/lib/src/database/daos/outgoing_message_dao.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/database/daos/outgoing_message_dao.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
+
 import 'package:libmsgr/src/database/constants.dart';
 import 'package:libmsgr/src/models/outgoing_message.dart';
+import 'package:libmsgr/libmsgr.dart';
 import 'package:sqflite_sqlcipher/sqflite.dart';
 
 class OutgoingMessageDao {
@@ -20,12 +23,14 @@ class OutgoingMessageDao {
     String messageId, {
     required DateTime attemptedAt,
     required int attemptCount,
+    MMessage? message,
   }) async {
     await _db.update(
       outgoingMessagesTable,
       <String, Object?>{
         'last_attempt_at': attemptedAt.toIso8601String(),
         'attempt_count': attemptCount,
+        if (message != null) 'payload': jsonEncode(message.toMap()),
       },
       where: 'message_id = ? AND team_name = ?',
       whereArgs: [messageId, teamName],

--- a/flutter_frontend/packages/libmsgr/lib/src/database/database.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/database/database.dart
@@ -4,6 +4,7 @@ import 'package:libmsgr/src/database/migrations/000_initial_migration.dart';
 import 'package:libmsgr/src/database/migrations/001_add_messages_and_contacts.dart';
 import 'package:libmsgr/src/database/migrations/002_profile_preferences.dart';
 import 'package:libmsgr/src/database/migrations/003_outgoing_message_queue.dart';
+import 'package:libmsgr/src/database/migrations/004_message_delivery_status.dart';
 import 'package:logging/logging.dart';
 import 'package:sqflite_common/src/sql_builder.dart';
 import 'package:sqflite_sqlcipher/sqflite.dart';
@@ -18,6 +19,7 @@ const List<Migration<DatabaseMigrationData>> migrations = [
   Migration(3, upgradeFromV2ToV3),
   Migration(4, upgradeFromV3ToV4),
   Migration(5, upgradeFromV4ToV5),
+  Migration(6, upgradeFromV5ToV6),
 ];
 
 class DatabaseService {

--- a/flutter_frontend/packages/libmsgr/lib/src/database/migrations/004_message_delivery_status.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/database/migrations/004_message_delivery_status.dart
@@ -1,0 +1,24 @@
+import 'package:libmsgr/src/database/constants.dart';
+import 'package:libmsgr/src/database/database.dart';
+import 'package:logging/logging.dart';
+import 'package:sqflite_sqlcipher/sqflite.dart';
+
+Future<void> upgradeFromV5ToV6(DatabaseMigrationData data) async {
+  final (Database db, Logger log) = data;
+
+  log.info('Adding delivery_status column to $messagesTable');
+
+  await db.execute(
+    'ALTER TABLE $messagesTable ADD COLUMN delivery_status TEXT NOT NULL DEFAULT "delivered"',
+  );
+
+  await db.execute(
+    '''
+    UPDATE $messagesTable
+    SET delivery_status = CASE
+      WHEN is_server_ack = 1 THEN 'delivered'
+      ELSE 'pending'
+    END
+    '''
+  );
+}

--- a/flutter_frontend/packages/libmsgr/lib/src/models/message.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/models/message.dart
@@ -2,6 +2,13 @@
 import 'package:libmsgr/src/models/base.dart';
 import 'package:meta/meta.dart';
 
+enum MessageDeliveryStatus {
+  pending,
+  sending,
+  delivered,
+  failed,
+}
+
 /// Represents a message model in the application.
 ///
 /// This class extends from `BaseModel` and is used to define the structure
@@ -19,6 +26,7 @@ class MMessage extends BaseModel {
   final String? inReplyToMsgID;
   final bool isServerAck;
   final bool isMsgRead;
+  final MessageDeliveryStatus deliveryStatus;
 
   bool get hasReactions => false;
 
@@ -33,7 +41,8 @@ class MMessage extends BaseModel {
       super.id = 'server-will-set-it',
       this.isServerAck = true,
       this.kIsSystemMsg = false,
-      this.isMsgRead = false}) {
+      this.isMsgRead = false,
+      this.deliveryStatus = MessageDeliveryStatus.delivered}) {
     if (conversationID == null && roomID == null) {
       throw ArgumentError('Either conversationID or roomID must be provided');
     }
@@ -46,7 +55,8 @@ class MMessage extends BaseModel {
         conversationID: conversationID,
         roomID: roomID,
         createdAt: DateTime.now(),
-        updatedAt: DateTime.now());
+        updatedAt: DateTime.now(),
+        deliveryStatus: MessageDeliveryStatus.delivered);
   }
 
   @override
@@ -62,7 +72,8 @@ class MMessage extends BaseModel {
           updatedAt == other.updatedAt &&
           kIsSystemMsg == other.kIsSystemMsg &&
           inReplyToMsgID == other.inReplyToMsgID &&
-          isMsgRead == other.isMsgRead;
+          isMsgRead == other.isMsgRead &&
+          deliveryStatus == other.deliveryStatus;
 
   @override
   int get hashCode =>
@@ -76,7 +87,8 @@ class MMessage extends BaseModel {
       updatedAt.hashCode ^
       kIsSystemMsg.hashCode ^
       inReplyToMsgID.hashCode ^
-      isMsgRead.hashCode;
+      isMsgRead.hashCode ^
+      deliveryStatus.hashCode;
 
   factory MMessage.fromMap(Map<String, dynamic> map) {
     return MMessage.raw(
@@ -105,6 +117,7 @@ class MMessage extends BaseModel {
           : map['is_msg_read'] == null
               ? false
               : (map['is_msg_read'] as num) != 0,
+      deliveryStatus: _statusFromValue(map['delivery_status']),
     );
   }
 
@@ -121,6 +134,7 @@ class MMessage extends BaseModel {
       'in_reply_to_id': inReplyToMsgID,
       'is_server_ack': isServerAck,
       'is_msg_read': isMsgRead,
+      'delivery_status': deliveryStatus.name,
     };
   }
 
@@ -135,7 +149,8 @@ class MMessage extends BaseModel {
         'inserted_at': String createdAt,
         'updated_at': String updatedAt,
         'is_system_msg': bool? kIsSystemMsg,
-        'in_reply_to_id': String? replyToID
+        'in_reply_to_id': String? replyToID,
+        'delivery_status': String? deliveryStatus,
       } =>
         MMessage.raw(
             id: id,
@@ -146,7 +161,8 @@ class MMessage extends BaseModel {
             createdAt: DateTime.parse(createdAt),
             updatedAt: DateTime.parse(updatedAt),
             kIsSystemMsg: kIsSystemMsg ?? false,
-            inReplyToMsgID: replyToID),
+            inReplyToMsgID: replyToID,
+            deliveryStatus: _statusFromValue(deliveryStatus)),
       _ => throw const FormatException('Failed to load message.'),
     };
   }
@@ -160,7 +176,8 @@ class MMessage extends BaseModel {
         'inserted_at': createdAt.toIso8601String(),
         'updated_at': updatedAt.toIso8601String(),
         'is_system_msg': kIsSystemMsg,
-        'in_reply_to_id': inReplyToMsgID
+        'in_reply_to_id': inReplyToMsgID,
+        'delivery_status': deliveryStatus.name
       };
 
   @override
@@ -184,6 +201,7 @@ class MMessage extends BaseModel {
     String? inReplyToMsgID,
     bool? isServerAck,
     bool? isMsgRead,
+    MessageDeliveryStatus? deliveryStatus,
   }) {
     return MMessage.raw(
       id: id ?? this.id,
@@ -197,6 +215,26 @@ class MMessage extends BaseModel {
       inReplyToMsgID: inReplyToMsgID ?? this.inReplyToMsgID,
       isServerAck: isServerAck ?? this.isServerAck,
       isMsgRead: isMsgRead ?? this.isMsgRead,
+      deliveryStatus: deliveryStatus ?? this.deliveryStatus,
     );
+  }
+
+  static MessageDeliveryStatus _statusFromValue(dynamic value) {
+    if (value == null) {
+      return MessageDeliveryStatus.delivered;
+    }
+
+    if (value is MessageDeliveryStatus) {
+      return value;
+    }
+
+    if (value is String) {
+      return MessageDeliveryStatus.values.firstWhere(
+        (status) => status.name == value,
+        orElse: () => MessageDeliveryStatus.delivered,
+      );
+    }
+
+    return MessageDeliveryStatus.delivered;
   }
 }

--- a/flutter_frontend/packages/libmsgr/lib/src/repositories/message_repository.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/repositories/message_repository.dart
@@ -42,6 +42,42 @@ class MessageRepository extends BaseRepository<MMessage> {
     }
   }
 
+  void updateDeliveryStatus(
+    String messageId,
+    MessageDeliveryStatus status, {
+    bool? isServerAck,
+  }) {
+    final message = _findMessage(messageId);
+
+    if (message == null) {
+      return;
+    }
+
+    final updated = message.copyWith(
+      deliveryStatus: status,
+      isServerAck: isServerAck ?? message.isServerAck,
+    );
+    _saveMessage(updated);
+  }
+
+  MMessage? _findMessage(String messageId) {
+    try {
+      return items.firstWhere((m) => m.id == messageId);
+    } catch (_) {
+      log.warning('Message $messageId not found when updating status');
+      return null;
+    }
+  }
+
+  void _saveMessage(MMessage message) {
+    final exists = items.any((element) => element.id == message.id);
+    if (exists) {
+      updateItem(message);
+    } else {
+      addItem(message);
+    }
+  }
+
   @override
   void fillLocalCache(List<MMessage> items) {
     super.fillLocalCache(items);
@@ -173,14 +209,20 @@ class MessageRepository extends BaseRepository<MMessage> {
 
   Future<Push?> sendMessageToRoom(MMessage msg) {
     return _enqueueAndSend(
-      msg.copyWith(isServerAck: false),
+      msg.copyWith(
+        isServerAck: false,
+        deliveryStatus: MessageDeliveryStatus.pending,
+      ),
       '$teamName.${msg.roomID!}',
     );
   }
 
   Future<Push?> sendMessageToConversation(MMessage msg) {
     return _enqueueAndSend(
-      msg.copyWith(isServerAck: false),
+      msg.copyWith(
+        isServerAck: false,
+        deliveryStatus: MessageDeliveryStatus.pending,
+      ),
       '$teamName.${msg.conversationID!}',
     );
   }
@@ -211,6 +253,10 @@ class MessageRepository extends BaseRepository<MMessage> {
         if (entry.attemptCount >= _maxAttempts) {
           log.warning(
             'Dropping message ${entry.message.id} after $_maxAttempts failed attempts',
+          );
+          updateDeliveryStatus(
+            entry.message.id,
+            MessageDeliveryStatus.failed,
           );
           await _outgoingDao.delete(teamName, entry.message.id);
           continue;
@@ -246,6 +292,8 @@ class MessageRepository extends BaseRepository<MMessage> {
   }
 
   Future<Push?> _enqueueAndSend(MMessage msg, String topic) async {
+    _saveMessage(msg);
+
     final entry = OutgoingMessage(message: msg, topic: topic);
     await _outgoingDao.enqueue(teamName, entry);
     final push = await _sendQueuedMessage(entry);
@@ -260,8 +308,12 @@ class MessageRepository extends BaseRepository<MMessage> {
       _scheduleRetry();
       return null;
     }
+    updateDeliveryStatus(entry.message.id, MessageDeliveryStatus.sending);
 
     final updatedEntry = entry.copyWith(
+      message: entry.message.copyWith(
+        deliveryStatus: MessageDeliveryStatus.sending,
+      ),
       lastAttemptAt: DateTime.now(),
       attemptCount: entry.attemptCount + 1,
     );
@@ -270,9 +322,10 @@ class MessageRepository extends BaseRepository<MMessage> {
       entry.message.id,
       attemptedAt: updatedEntry.lastAttemptAt!,
       attemptCount: updatedEntry.attemptCount,
+      message: updatedEntry.message,
     );
 
-    final push = wsConn.sendMessage(entry.topic, entry.message);
+    final push = wsConn.sendMessage(entry.topic, updatedEntry.message);
     if (push == null) {
       log.severe('Error sending message: Push is null');
       _scheduleRetry();

--- a/flutter_frontend/packages/libmsgr/test/database/message_dao_test.dart
+++ b/flutter_frontend/packages/libmsgr/test/database/message_dao_test.dart
@@ -43,6 +43,7 @@ void main() {
       expect(stored, hasLength(1));
       expect(stored.single.id, message.id);
       expect(stored.single.content, message.content);
+      expect(stored.single.deliveryStatus, MessageDeliveryStatus.delivered);
     });
 
     test('filters by team name', () async {

--- a/flutter_frontend/packages/libmsgr/test/repositories/message_repository_test.dart
+++ b/flutter_frontend/packages/libmsgr/test/repositories/message_repository_test.dart
@@ -77,11 +77,16 @@ void main() {
     var pending = await outgoingDao.getPending('team-a');
     expect(pending, hasLength(1));
 
+    final storedMessages = await messageDao.getMessagesForTeam('team-a');
+    expect(storedMessages.single.deliveryStatus, MessageDeliveryStatus.sending);
+
     pushCompleter.complete({'status': 'ok'});
     await Future<void>.delayed(const Duration(milliseconds: 10));
 
     pending = await outgoingDao.getPending('team-a');
     expect(pending, isEmpty);
+    final delivered = await messageDao.getMessagesForTeam('team-a');
+    expect(delivered.single.deliveryStatus, MessageDeliveryStatus.delivered);
     verify(connection.sendMessage('team-a.room-1', any)).called(1);
   });
 
@@ -110,5 +115,17 @@ void main() {
 
     pending = await outgoingDao.getPending('team-a');
     expect(pending, isEmpty);
+  });
+
+  test('marks message as failed on socket error', () async {
+    final msg = _sampleMessage(roomId: 'room-3', id: 'fail-msg');
+
+    await repository.sendMessageToRoom(msg);
+
+    pushCompleter.completeError(Exception('boom'));
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    final stored = await messageDao.getMessagesForTeam('team-a');
+    expect(stored.single.deliveryStatus, MessageDeliveryStatus.failed);
   });
 }


### PR DESCRIPTION
## Summary
- add delivery status to messages and persist it with new database migration
- update websocket sending to mark messages pending/sending/delivered/failed and notify repository listeners
- extend DAO/repository tests for delivery status handling

## Testing
- Not run (flutter/dart SDK not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ec97d1dcc8322bacb03f268317c97)