### PR TITLE
Improve websocket send resilience and telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@
 - Completed the CLI migration by deleting the legacy `libmsgr/tool` forwarder,
   fixing the standalone `libmsgr_cli` binary and pointing integration tests to
   `packages/libmsgr_cli/bin/msgr.dart`.
+- Hardened the Flutter websocket send path with offline detection, queued
+  retries (exponential backoff, max-attempt tracking), reconnection replay, and
+  telemetry for retry outcomes so clients can surface resilient delivery states
+  to users and logs.
 
 ### Observability
 

--- a/flutter_frontend/packages/libmsgr/lib/src/connection.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/connection.dart
@@ -72,6 +72,7 @@ class MsgrConnection {
     _presence.onSync = presenceOnSync;
     final repos = LibMsgr().repositoryFactory.getRepositories(tenant);
     await repos.messageRepository.onConnectionChanged(isConnected: true);
+    unawaited(_replayPendingMessages());
   }
 
   void _handleDisconnect(event) {
@@ -79,6 +80,11 @@ class MsgrConnection {
     _connected = false;
     final repos = LibMsgr().repositoryFactory.getRepositories(tenant);
     unawaited(repos.messageRepository.onConnectionChanged(isConnected: false));
+  }
+
+  Future<void> _replayPendingMessages() async {
+    final repos = LibMsgr().repositoryFactory.getRepositories(tenant);
+    await repos.messageRepository.processPendingQueue();
   }
 
   List<Room> _handleRoomsPacket(
@@ -180,52 +186,73 @@ class MsgrConnection {
 
   Push? sendMessage(String destID, MMessage msg) {
     final key = (msg.roomID != null) ? 'room:$destID' : 'conversation:$destID';
-    if (_socket.channels.containsKey(key)) {
-      final chl = _socket.channels[key]!;
-      SocketTelemetry.instance.messageSent(
+    if (!_connected) {
+      _log.warning('Socket disconnected; queuing message ${msg.id} for retry');
+      SocketTelemetry.instance.messageRetryScheduled(
         conversationId: msg.conversationID ?? msg.roomID ?? destID,
         messageId: msg.id,
-        metadata: {'topic': key},
+        metadata: {
+          'topic': key,
+          'reason': 'socket_disconnected',
+        },
       );
-
-      final push = chl.push('create:msg', msg.toMap());
-      push?.future.then((response) {
-        final repos = LibMsgr().repositoryFactory.getRepositories(tenant);
-        repos.messageRepository.updateDeliveryStatus(
-          msg.id,
-          MessageDeliveryStatus.delivered,
-          isServerAck: true,
-        );
-        SocketTelemetry.instance.messageAcknowledged(
-          conversationId: msg.conversationID ?? msg.roomID ?? destID,
-          messageId: msg.id,
-          metadata: {
-            'topic': key,
-            'status': response?.status ?? 'ok',
-          },
-        );
-      }).catchError((error) {
-        final repos = LibMsgr().repositoryFactory.getRepositories(tenant);
-        repos.messageRepository.updateDeliveryStatus(
-          msg.id,
-          MessageDeliveryStatus.failed,
-        );
-        SocketTelemetry.instance.messageAcknowledged(
-          conversationId: msg.conversationID ?? msg.roomID ?? destID,
-          messageId: msg.id,
-          metadata: {
-            'topic': key,
-            'status': 'error',
-            'error': error.toString(),
-          },
-        );
-      });
-
-      return push;
-    } else {
-      _log.severe('Channel $destID not found!');
-      throw Exception('Channel $destID not found!');
+      return null;
     }
+
+    if (!_socket.channels.containsKey(key)) {
+      _log.warning('Channel $key not found; queuing message ${msg.id} for retry');
+      SocketTelemetry.instance.messageRetryScheduled(
+        conversationId: msg.conversationID ?? msg.roomID ?? destID,
+        messageId: msg.id,
+        metadata: {
+          'topic': key,
+          'reason': 'channel_missing',
+        },
+      );
+      return null;
+    }
+
+    final chl = _socket.channels[key]!;
+    SocketTelemetry.instance.messageSent(
+      conversationId: msg.conversationID ?? msg.roomID ?? destID,
+      messageId: msg.id,
+      metadata: {'topic': key},
+    );
+
+    final push = chl.push('create:msg', msg.toMap());
+    push?.future.then((response) {
+      final repos = LibMsgr().repositoryFactory.getRepositories(tenant);
+      repos.messageRepository.updateDeliveryStatus(
+        msg.id,
+        MessageDeliveryStatus.delivered,
+        isServerAck: true,
+      );
+      SocketTelemetry.instance.messageAcknowledged(
+        conversationId: msg.conversationID ?? msg.roomID ?? destID,
+        messageId: msg.id,
+        metadata: {
+          'topic': key,
+          'status': response?.status ?? 'ok',
+        },
+      );
+    }).catchError((error) {
+      final repos = LibMsgr().repositoryFactory.getRepositories(tenant);
+      repos.messageRepository.updateDeliveryStatus(
+        msg.id,
+        MessageDeliveryStatus.failed,
+      );
+      SocketTelemetry.instance.messageAcknowledged(
+        conversationId: msg.conversationID ?? msg.roomID ?? destID,
+        messageId: msg.id,
+        metadata: {
+          'topic': key,
+          'status': 'error',
+          'error': error.toString(),
+        },
+      );
+    });
+
+    return push;
   }
 
   Push? createRoom(String profileID, String roomName, String roomDescription,

--- a/flutter_frontend/packages/libmsgr/lib/src/repositories/message_repository.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/repositories/message_repository.dart
@@ -6,6 +6,7 @@ import 'package:libmsgr/src/database/daos/message_dao.dart';
 import 'package:libmsgr/src/database/daos/outgoing_message_dao.dart';
 import 'package:libmsgr/src/models/outgoing_message.dart';
 import 'package:libmsgr/src/repositories/base.dart';
+import 'package:libmsgr/src/telemetry/socket_telemetry.dart';
 import 'package:libmsgr/src/typedefs.dart';
 import 'package:phoenix_socket/phoenix_socket.dart';
 
@@ -258,6 +259,14 @@ class MessageRepository extends BaseRepository<MMessage> {
             entry.message.id,
             MessageDeliveryStatus.failed,
           );
+          SocketTelemetry.instance.messageRetryExhausted(
+            conversationId: entry.message.conversationID ?? entry.message.roomID,
+            messageId: entry.message.id,
+            metadata: {
+              'attempts': entry.attemptCount,
+              'topic': entry.topic,
+            },
+          );
           await _outgoingDao.delete(teamName, entry.message.id);
           continue;
         }
@@ -305,6 +314,15 @@ class MessageRepository extends BaseRepository<MMessage> {
     final wsConn = _connectionProvider();
     if (wsConn == null || !wsConn.isConnected()) {
       log.warning('No active websocket connection; will retry ${entry.message.id}');
+      SocketTelemetry.instance.messageRetryScheduled(
+        conversationId: entry.message.conversationID ?? entry.message.roomID,
+        messageId: entry.message.id,
+        metadata: {
+          'attempts': entry.attemptCount,
+          'topic': entry.topic,
+          'reason': 'connection_unavailable',
+        },
+      );
       _scheduleRetry();
       return null;
     }
@@ -328,14 +346,45 @@ class MessageRepository extends BaseRepository<MMessage> {
     final push = wsConn.sendMessage(entry.topic, updatedEntry.message);
     if (push == null) {
       log.severe('Error sending message: Push is null');
+      updateDeliveryStatus(entry.message.id, MessageDeliveryStatus.pending);
+      SocketTelemetry.instance.messageRetryScheduled(
+        conversationId: entry.message.conversationID ?? entry.message.roomID,
+        messageId: entry.message.id,
+        metadata: {
+          'attempts': updatedEntry.attemptCount,
+          'topic': entry.topic,
+          'reason': 'channel_unavailable',
+        },
+      );
       _scheduleRetry();
       return null;
     }
 
     push.future.then((value) async {
+      if (updatedEntry.attemptCount > 1) {
+        SocketTelemetry.instance.messageRetrySucceeded(
+          conversationId: updatedEntry.message.conversationID ?? updatedEntry.message.roomID,
+          messageId: updatedEntry.message.id,
+          metadata: {
+            'attempts': updatedEntry.attemptCount,
+            'topic': entry.topic,
+          },
+        );
+      }
       await _outgoingDao.delete(teamName, entry.message.id);
     }).catchError((e) async {
       log.severe('Error sending message ${entry.message.id}: $e');
+      updateDeliveryStatus(entry.message.id, MessageDeliveryStatus.pending);
+      SocketTelemetry.instance.messageRetryScheduled(
+        conversationId: entry.message.conversationID ?? entry.message.roomID,
+        messageId: entry.message.id,
+        metadata: {
+          'attempts': updatedEntry.attemptCount,
+          'topic': entry.topic,
+          'reason': 'send_error',
+          'error': e.toString(),
+        },
+      );
       _scheduleRetry();
     });
     return push;

--- a/flutter_frontend/packages/libmsgr/lib/src/telemetry/socket_telemetry.dart
+++ b/flutter_frontend/packages/libmsgr/lib/src/telemetry/socket_telemetry.dart
@@ -56,6 +56,45 @@ class SocketTelemetry {
     );
   }
 
+  void messageRetryScheduled({
+    String? conversationId,
+    String? messageId,
+    Map<String, Object?> metadata = const {},
+  }) {
+    _record(
+      name: 'message.retry_scheduled',
+      conversationId: conversationId,
+      messageId: messageId,
+      metadata: metadata,
+    );
+  }
+
+  void messageRetrySucceeded({
+    String? conversationId,
+    String? messageId,
+    Map<String, Object?> metadata = const {},
+  }) {
+    _record(
+      name: 'message.retry_succeeded',
+      conversationId: conversationId,
+      messageId: messageId,
+      metadata: metadata,
+    );
+  }
+
+  void messageRetryExhausted({
+    String? conversationId,
+    String? messageId,
+    Map<String, Object?> metadata = const {},
+  }) {
+    _record(
+      name: 'message.retry_exhausted',
+      conversationId: conversationId,
+      messageId: messageId,
+      metadata: metadata,
+    );
+  }
+
   void typingStarted({
     String? conversationId,
     String? threadId,

--- a/flutter_frontend/packages/libmsgr/test/repositories/message_repository_test.dart
+++ b/flutter_frontend/packages/libmsgr/test/repositories/message_repository_test.dart
@@ -6,6 +6,7 @@ import 'package:libmsgr/src/database/daos/message_dao.dart';
 import 'package:libmsgr/src/database/daos/outgoing_message_dao.dart';
 import 'package:libmsgr/src/database/database.dart';
 import 'package:libmsgr/src/repositories/message_repository.dart';
+import 'package:libmsgr/src/telemetry/socket_telemetry.dart';
 import 'package:mockito/mockito.dart';
 import 'package:phoenix_socket/phoenix_socket.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
@@ -26,6 +27,8 @@ void main() {
   late MockMsgrConnection connection;
   late MockPush push;
   late Completer<dynamic> pushCompleter;
+  late StreamSubscription<SocketEvent> telemetrySubscription;
+  final List<SocketEvent> telemetry = [];
   var connected = true;
 
   setUp(() async {
@@ -37,10 +40,14 @@ void main() {
     push = MockPush();
     pushCompleter = Completer<dynamic>();
     connected = true;
+    telemetry.clear();
 
     when(connection.isConnected()).thenAnswer((_) => connected);
     when(push.future).thenAnswer((_) => pushCompleter.future);
     when(connection.sendMessage(any, any)).thenReturn(push);
+
+    telemetrySubscription =
+        SocketTelemetry.instance.events.listen(telemetry.add);
 
     repository = MessageRepository(
       teamName: 'team-a',
@@ -54,6 +61,7 @@ void main() {
     final path = databaseService.instance.path;
     await databaseService.instance.close();
     await databaseFactory.deleteDatabase(path);
+    await telemetrySubscription.cancel();
   });
 
   MMessage _sampleMessage({String id = 'msg-1', String? roomId, String? conversationId}) {
@@ -88,6 +96,47 @@ void main() {
     final delivered = await messageDao.getMessagesForTeam('team-a');
     expect(delivered.single.deliveryStatus, MessageDeliveryStatus.delivered);
     verify(connection.sendMessage('team-a.room-1', any)).called(1);
+  });
+
+  test('emits telemetry for retry scheduling and success after reconnection',
+      () async {
+    connected = false;
+    when(connection.sendMessage(any, any)).thenReturn(null);
+    final msg = _sampleMessage(roomId: 'room-telemetry');
+
+    await repository.sendMessageToRoom(msg);
+
+    expect(
+      telemetry.where((e) => e.name == 'message.retry_scheduled'),
+      isNotEmpty,
+    );
+
+    connected = true;
+    pushCompleter = Completer<dynamic>();
+    when(push.future).thenAnswer((_) => pushCompleter.future);
+    when(connection.sendMessage(any, any)).thenReturn(push);
+
+    // Mark the previous attempt as failed to trigger a retry attempt count > 1
+    final pending = (await outgoingDao.getPending('team-a')).single;
+    await outgoingDao.markAttempt(
+      'team-a',
+      pending.message.id,
+      attemptedAt: DateTime.now().subtract(const Duration(seconds: 5)),
+      attemptCount: 1,
+      message: pending.message.copyWith(
+        deliveryStatus: MessageDeliveryStatus.pending,
+      ),
+    );
+
+    await repository.processPendingQueue();
+
+    pushCompleter.complete({'status': 'ok'});
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(
+      telemetry.where((e) => e.name == 'message.retry_succeeded'),
+      isNotEmpty,
+    );
   });
 
   test('retries pending messages when the connection comes back', () async {
@@ -127,5 +176,31 @@ void main() {
 
     final stored = await messageDao.getMessagesForTeam('team-a');
     expect(stored.single.deliveryStatus, MessageDeliveryStatus.failed);
+  });
+
+  test('emits telemetry when retries are exhausted', () async {
+    connected = true;
+    final msg = _sampleMessage(roomId: 'room-4', id: 'exhaust-msg');
+
+    await repository.sendMessageToRoom(msg);
+
+    // Force the entry to exceed the max attempts
+    final entry = (await outgoingDao.getPending('team-a')).single;
+    await outgoingDao.markAttempt(
+      'team-a',
+      entry.message.id,
+      attemptedAt: DateTime.now().subtract(const Duration(minutes: 1)),
+      attemptCount: 5,
+      message: entry.message,
+    );
+
+    await repository.processPendingQueue();
+
+    final stored = await messageDao.getMessagesForTeam('team-a');
+    expect(stored.single.deliveryStatus, MessageDeliveryStatus.failed);
+    expect(
+      telemetry.where((e) => e.name == 'message.retry_exhausted'),
+      isNotEmpty,
+    );
   });
 }


### PR DESCRIPTION
## Summary
- make websocket send path tolerant of disconnected or missing channels and queue messages for retry
- replay pending sends on reconnect with backoff/attempt tracking and expose retry telemetry for UI surfacing
- extend message repository tests and changelog entry for the resilient send behaviour

## Testing
- flutter test *(fails: flutter command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693edf184db083228df1d474f2a5ddf3)