### PR TITLE
fix(security): secrets out of compose, SEC-8 cleanup, atomic OTP lockout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,46 +1,62 @@
-# Copy this file to .env to configure the local development stack.
-# Values left blank will fall back to the defaults defined in config/dev.exs.
+# Copy this file to `.env` before starting the local Docker stack:
+#   cp .env.example .env
+#
+# Generate strong values for every REQUIRED secret below. Never commit `.env`.
+# See docs/SECRET_MANAGEMENT.md for production guidance.
+
+# --- Required secrets (compose fails if unset) ---------------------------
+# Phoenix / Guardian signing key (64+ bytes of entropy, base64 or hex).
+#   openssl rand -base64 64
+SECRET_KEY_BASE=
+
+# Noise gateway static key (32 bytes, base64).
+#   openssl rand -base64 32
+SERVER_STATIC_KEY=
+
+# Postgres password shared by `db` and `backend` services.
+POSTGRES_PASSWORD=
+
+# Observability UI credentials
+GF_SECURITY_ADMIN_PASSWORD=
+ZO_ROOT_USER_PASSWORD=
+
+# --- Optional / recommended ---------------------------------------------
+# HMAC secret for OTP code hashing. Falls back to SECRET_KEY_BASE if empty.
+#   openssl rand -base64 32
+OTP_HMAC_SECRET=
+
+POSTGRES_USERNAME=postgres
+POSTGRES_DB=msgr_dev
+REDIS_URL=redis://msgr_redis:6379
+
+GF_SECURITY_ADMIN_USER=admin
+GF_AUTH_ANONYMOUS_ENABLED=false
+ZO_ROOT_USER_EMAIL=root@example.com
 
 # --- TLS configuration ---------------------------------------------------
-# Enable the Phoenix HTTPS listener and optional force-SSL redirects.
 MSGR_TLS_ENABLED=false
-# Port exposed by the HTTPS listener when TLS is enabled (docker-compose maps it automatically).
 MSGR_TLS_PORT=4443
-# Absolute paths to the certificate and key inside the backend container.
 MSGR_TLS_CERT_PATH=
 MSGR_TLS_KEY_PATH=
-# Optional CA bundle if you are using a custom certificate authority.
 MSGR_TLS_CACERT_PATH=
-# Set to true to enable Plug.SSL redirects (HSTS is disabled by default).
 MSGR_FORCE_SSL=false
-# Enable HTTP Strict Transport Security when MSGR_FORCE_SSL=true.
 MSGR_FORCE_SSL_HSTS=false
 
 # --- Noise transport configuration ---------------------------------------
-# Toggle the Noise transport/server used for encrypted handshakes.
 NOISE_TRANSPORT_ENABLED=false
-# TCP port for the Noise transport listener (docker-compose maps it automatically).
 NOISE_TRANSPORT_PORT=5443
-# Provide a base64-encoded static key when not loading from Secrets Manager.
 NOISE_STATIC_KEY=
-# Optional AWS Secrets Manager location for the Noise static key material.
 NOISE_STATIC_KEY_SECRET_ID=
 NOISE_STATIC_KEY_SECRET_FIELD=private
 NOISE_STATIC_KEY_SECRET_REGION=
-# Document when the static key was last rotated (ISO8601 timestamp).
 NOISE_STATIC_KEY_ROTATED_AT=
 
-# --- Redis configuration -------------------------------------------------
-# Used for caching, PubSub, and session storage.
-REDIS_URL=redis://msgr_redis:6379
-
 # --- MinIO (S3-compatible object storage) --------------------------------
-# Credentials for the local MinIO instance (media uploads, file storage).
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
-# Endpoint URL used by the backend to connect to MinIO.
-MINIO_ENDPOINT=http://msgr_minio:9000
+MINIO_ENDPOINT=http://msgr-minio:9000
+MINIO_PUBLIC_HOST=localhost
+MINIO_PUBLIC_PORT=9000
 
 # --- Legacy actor headers ------------------------------------------------
-# Enable legacy X-Actor-* headers for backward compatibility.
 MSGR_WEB_LEGACY_ACTOR_HEADERS=false

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Flutter-appar og støtteverktøy.
 
 ```bash
 cp .env.example .env
+# Fill required secrets (SECRET_KEY_BASE, SERVER_STATIC_KEY, …) — see docs/SECRET_MANAGEMENT.md
 docker compose up --build
 ```
 
@@ -32,5 +33,6 @@ Backenden starter da på port `4000` (HTTP) og, dersom TLS er aktivert, på
 - [architecture.md](architecture.md) – høynivå arkitektur og mål.
 - [docs/architecture_alignment.md](docs/architecture_alignment.md) – siste
   status på hvordan kodebasen matcher arkitekturprinsippene.
+- [docs/SECRET_MANAGEMENT.md](docs/SECRET_MANAGEMENT.md) – secrets for lokal og prod.
 - [backend/README.md](backend/README.md) – detaljer om Docker-stacken og
   backend-konfigurasjon.

--- a/backend/README.md
+++ b/backend/README.md
@@ -54,9 +54,10 @@ docker compose build stonemq --build-arg STONEMQ_REF=<commit-eller-branch>
 - Sett `PROMETHEUS_ENABLED=false` dersom du vil skru av eksportøren i et
   begrenset miljø. Porten kan overstyres med `PROMETHEUS_PORT`.
 - **Grafana** startes med en forhåndsprovisjonert Prometheus-datakilde og er
-  tilgjengelig på `http://localhost:3000` (bruker/pass: `admin`/`admin`).
-- **OpenObserve** håndterer loggdata på `http://localhost:5080`. Standardbrukeren
-  er `root@example.com` med passord `Complexpass#123`.
+  tilgjengelig på `http://localhost:3000` (bruker/pass fra
+  `GF_SECURITY_ADMIN_USER` / `GF_SECURITY_ADMIN_PASSWORD` i `.env`).
+- **OpenObserve** håndterer loggdata på `http://localhost:5088`
+  (`ZO_ROOT_USER_EMAIL` / `ZO_ROOT_USER_PASSWORD` i `.env`).
 
 Backenden publiserer applikasjonslogger via StoneMQ-topicen `observability/logs`
 ved hjelp av `Messngr.Logging.OpenObserveBackend`. En dedikert konsument kan

--- a/backend/apps/msgr/lib/msgr/auth.ex
+++ b/backend/apps/msgr/lib/msgr/auth.ex
@@ -451,20 +451,30 @@ defmodule Messngr.Auth do
     import Ecto.Query
 
     now = DateTime.utc_now() |> DateTime.truncate(:second)
+    max_attempts = @max_verify_attempts
 
-    # Atomic increment so concurrent wrong guesses cannot lose attempts.
+    # Single UPDATE: increment + lockout at threshold are atomic under concurrency.
     {updated, rows} =
       from(c in Challenge,
         where: c.id == ^id and is_nil(c.consumed_at),
+        update: [
+          set: [
+            attempt_count: fragment("? + 1", c.attempt_count),
+            consumed_at:
+              fragment(
+                "CASE WHEN ? + 1 >= ? THEN ? ELSE consumed_at END",
+                c.attempt_count,
+                ^max_attempts,
+                ^now
+              )
+          ]
+        ],
         select: c.attempt_count
       )
-      |> Repo.update_all(inc: [attempt_count: 1])
+      |> Repo.update_all([])
 
     case {updated, rows} do
-      {1, [count]} when is_integer(count) and count >= @max_verify_attempts ->
-        from(c in Challenge, where: c.id == ^id and is_nil(c.consumed_at))
-        |> Repo.update_all(set: [consumed_at: now])
-
+      {1, [count]} when is_integer(count) and count >= max_attempts ->
         {:error, :too_many_attempts}
 
       {1, _} ->

--- a/backend/apps/msgr/lib/msgr/auth.ex
+++ b/backend/apps/msgr/lib/msgr/auth.ex
@@ -447,25 +447,31 @@ defmodule Messngr.Auth do
     end
   end
 
-  defp record_failed_attempt(%Challenge{} = challenge) do
-    next_count = (challenge.attempt_count || 0) + 1
+  defp record_failed_attempt(%Challenge{id: id}) do
+    import Ecto.Query
 
-    attrs =
-      if next_count >= @max_verify_attempts do
-        %{"attempt_count" => next_count, "consumed_at" => DateTime.utc_now()}
-      else
-        %{"attempt_count" => next_count}
-      end
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    case challenge |> Challenge.changeset(attrs) |> Repo.update() do
-      {:ok, _updated} when next_count >= @max_verify_attempts ->
+    # Atomic increment so concurrent wrong guesses cannot lose attempts.
+    {updated, rows} =
+      from(c in Challenge,
+        where: c.id == ^id and is_nil(c.consumed_at),
+        select: c.attempt_count
+      )
+      |> Repo.update_all(inc: [attempt_count: 1])
+
+    case {updated, rows} do
+      {1, [count]} when is_integer(count) and count >= @max_verify_attempts ->
+        from(c in Challenge, where: c.id == ^id and is_nil(c.consumed_at))
+        |> Repo.update_all(set: [consumed_at: now])
+
         {:error, :too_many_attempts}
 
-      {:ok, _updated} ->
+      {1, _} ->
         {:error, :invalid_code}
 
-      {:error, reason} ->
-        {:error, reason}
+      {0, _} ->
+        {:error, :too_many_attempts}
     end
   end
 

--- a/backend/apps/msgr_web/lib/msgr_web/plugs/current_actor.ex
+++ b/backend/apps/msgr_web/lib/msgr_web/plugs/current_actor.ex
@@ -1,7 +1,7 @@
 defmodule MessngrWeb.Plugs.CurrentActor do
   @moduledoc """
-  Wrapper around `MessngrWeb.Plugs.SessionContext` for extracting session
-  information from Rust Gateway headers.
+  Wrapper around `MessngrWeb.Plugs.SessionContext` that authenticates the
+  request from a Guardian JWT (`Authorization: Bearer …`).
   """
 
   alias MessngrWeb.Plugs.SessionContext

--- a/backend/apps/msgr_web/lib/msgr_web/plugs/session_context.ex
+++ b/backend/apps/msgr_web/lib/msgr_web/plugs/session_context.ex
@@ -1,13 +1,10 @@
 defmodule MessngrWeb.Plugs.SessionContext do
   @moduledoc """
-  Extract session context from JWT Bearer token or headers injected by Rust Gateway.
+  Authenticate the request from a Guardian JWT Bearer token and load account/profile assigns.
 
-  Authentication priority:
-  1. Authorization: Bearer <JWT> header — decode JWT, extract account_id, profile_id, teams
-  2. X-Account-Id / X-Profile-Id / X-Device-Id / X-Session-Id headers (backward compat)
-
-  This plug reads the authentication data and loads the corresponding database records,
-  making them available to controllers and channels via assigns.
+  Expects `Authorization: Bearer <access JWT>`. Invalid or missing tokens are rejected
+  with HTTP 401. Actor identity is taken only from verified JWT claims (`sub`, `pid`, `ten`)
+  — legacy `X-Account-Id` / `X-Profile-Id` headers are not trusted.
   """
 
   import Plug.Conn

--- a/backend/apps/msgr_web/lib/msgr_web/router.ex
+++ b/backend/apps/msgr_web/lib/msgr_web/router.ex
@@ -6,7 +6,7 @@ defmodule MessngrWeb.Router do
   end
 
   pipeline :actor do
-    plug MessngrWeb.Plugs.CurrentActor, authorization_schemes: [:noise]
+    plug MessngrWeb.Plugs.CurrentActor
   end
 
   pipeline :browser do

--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -134,7 +134,8 @@ if Code.ensure_loaded?(Messngr.Logging.OpenObserveBackend) do
       stream: "backend",
       dataset: "_json",
       username: "root@example.com",
-      password: "Complexpass#123",
+      # Override via OPENOBSERVE_PASSWORD in runtime/dev config — do not ship real secrets here.
+      password: "",
       metadata: [:application, :module, :function, :line, :request_id, :pid],
       level: :info,
       service: "msgr_backend"

--- a/backend/config/dev.exs
+++ b/backend/config/dev.exs
@@ -104,7 +104,7 @@ openobserve_opts = [
   stream: System.get_env("OPENOBSERVE_STREAM", "backend"),
   dataset: System.get_env("OPENOBSERVE_DATASET", "_json"),
   username: System.get_env("OPENOBSERVE_USERNAME", "root@example.com"),
-  password: System.get_env("OPENOBSERVE_PASSWORD", "Complexpass#123"),
+  password: System.get_env("OPENOBSERVE_PASSWORD", ""),
   metadata: [:application, :module, :function, :line, :request_id, :pid],
   level: :debug,
   service: System.get_env("OPENOBSERVE_SERVICE", "msgr_backend_dev"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     image: postgres:15
     container_name: msgr_db
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: msgr_dev
+      POSTGRES_USER: ${POSTGRES_USERNAME:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-msgr_dev}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
@@ -78,7 +78,7 @@ services:
     environment:
       HTTP_PORT: 8443
       GRPC_PORT: 50053
-      SERVER_STATIC_KEY: JPyIbVodh4N+o1F98UFcPdK3TeZ3t6VjkxTsauDiLYc=
+      SERVER_STATIC_KEY: ${SERVER_STATIC_KEY:?Set SERVER_STATIC_KEY in .env}
       BACKEND_URL: http://backend:4000
       ELIXIR_GRPC_URL: http://backend:50052
       SESSION_DEFAULT_TTL_SECONDS: 3600
@@ -126,15 +126,16 @@ services:
       PHX_LISTEN_IP: 0.0.0.0
       PHX_HOST: 0.0.0.0
       POSTGRES_HOST: db
-      POSTGRES_USERNAME: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USERNAME: ${POSTGRES_USERNAME:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
       PORT: 4000
       RUST_GATEWAY_HOST: rust_gateway
       RUST_GATEWAY_GRPC_PORT: 50053
       RUST_GATEWAY_SERVER_PORT: 50052
-      REDIS_URL: redis://msgr_redis:6379
+      REDIS_URL: ${REDIS_URL:-redis://msgr_redis:6379}
       MSGR_WEB_LEGACY_ACTOR_HEADERS: ${MSGR_WEB_LEGACY_ACTOR_HEADERS:-false}
-      SECRET_KEY_BASE: 3X6X5EiV0HEhNAZCFKuGcZNl14Q8U5hZ4qQlR9VuQ07oVcTyVwW7BrPPW5zSOdaT
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:?Set SECRET_KEY_BASE in .env}
+      OTP_HMAC_SECRET: ${OTP_HMAC_SECRET:-}
       NOISE_TRANSPORT_ENABLED: ${NOISE_TRANSPORT_ENABLED:-false}
       NOISE_TRANSPORT_PORT: ${NOISE_TRANSPORT_PORT:-5443}
       NOISE_STATIC_KEY: ${NOISE_STATIC_KEY:-}
@@ -191,9 +192,9 @@ services:
     image: grafana/grafana:11.0.0
     container_name: msgr_grafana
     environment:
-      GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_ADMIN_PASSWORD: admin
-      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_SECURITY_ADMIN_USER: ${GF_SECURITY_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD:?Set GF_SECURITY_ADMIN_PASSWORD in .env}
+      GF_AUTH_ANONYMOUS_ENABLED: ${GF_AUTH_ANONYMOUS_ENABLED:-false}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./docker/grafana/provisioning:/etc/grafana/provisioning:ro
@@ -213,8 +214,8 @@ services:
     image: public.ecr.aws/zinclabs/openobserve:latest
     container_name: msgr_openobserve
     environment:
-      ZO_ROOT_USER_EMAIL: root@example.com
-      ZO_ROOT_USER_PASSWORD: Complexpass#123
+      ZO_ROOT_USER_EMAIL: ${ZO_ROOT_USER_EMAIL:-root@example.com}
+      ZO_ROOT_USER_PASSWORD: ${ZO_ROOT_USER_PASSWORD:?Set ZO_ROOT_USER_PASSWORD in .env}
       ZO_DATA_DIR: /data
       ZO_TELEMETRY: "false"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "127.0.0.1:5433:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\""]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docs/CODEBASE_ANALYSIS.md
+++ b/docs/CODEBASE_ANALYSIS.md
@@ -109,7 +109,7 @@
 | Mangel | Beskrivelse | Prioritet |
 |--------|-------------|-----------|
 | **Double Ratchet E2EE** | Kun tabellstruktur (`OmemoRatchets`), ingen faktisk implementasjon | P0 |
-| **Secret Management** | Hardkodede secrets i docker-compose (SECRET_KEY_BASE) | P0 |
+| **Secret Management** | Secrets skal komme fra `.env` / secret store (se `docs/SECRET_MANAGEMENT.md`) | P0 |
 | **Database HA** | Ingen Patroni/HA-konfigurasjon | P0 |
 | **Database Backup** | Ingen backup-strategi dokumentert/implementert | P0 |
 | **SSL/TLS Sertifikater** | Produksjon krever gyldige sertifikater, kun toggle-støtte | P0 |

--- a/docs/SECRET_MANAGEMENT.md
+++ b/docs/SECRET_MANAGEMENT.md
@@ -1,0 +1,44 @@
+# Secret management
+
+Hardcoded secrets must not live in version control. Local Docker and production both load secrets from the environment (or a secret manager that injects env vars).
+
+## Local development
+
+1. Copy the example file: `cp .env.example .env`
+2. Fill every required value (compose uses `${VAR:?…}` and will refuse to start if missing):
+   - `SECRET_KEY_BASE` — `openssl rand -base64 64`
+   - `SERVER_STATIC_KEY` — `openssl rand -base64 32`
+   - `POSTGRES_PASSWORD`
+   - `GF_SECURITY_ADMIN_PASSWORD`
+   - `ZO_ROOT_USER_PASSWORD`
+3. Optionally set `OTP_HMAC_SECRET` (`openssl rand -base64 32`). If unset, the backend falls back to `SECRET_KEY_BASE`.
+4. Start the stack: `docker compose up -d`
+
+`.env` is gitignored. Never commit real credentials.
+
+## Production
+
+| Secret | Used for | Source |
+| --- | --- | --- |
+| `SECRET_KEY_BASE` | Phoenix cookie + Guardian JWT signing | Required env / secret store |
+| `OTP_HMAC_SECRET` | HMAC of OTP codes at rest | Preferred dedicated secret; falls back to `SECRET_KEY_BASE` |
+| `SERVER_STATIC_KEY` | Rust Noise gateway identity | Required env / secret store |
+| `POSTGRES_PASSWORD` | Database auth | Required env / secret store |
+| `NOISE_STATIC_KEY` / `NOISE_STATIC_KEY_SECRET_ID` | Elixir Noise static key | Env, or AWS Secrets Manager via existing runtime hooks |
+
+### Recommended store
+
+Prefer a managed secret store over long-lived plaintext env files on disk:
+
+1. **AWS Secrets Manager** / **SSM Parameter Store** — already partially wired for Noise static keys (`NOISE_STATIC_KEY_SECRET_*`).
+2. **HashiCorp Vault** — inject at deploy time (Kubernetes CSI / Vault Agent / Terraform).
+3. **Platform secrets** (Fly.io / Railway / ECS task secrets) — map 1:1 to the env vars above.
+
+Rotate `SECRET_KEY_BASE` and `SERVER_STATIC_KEY` carefully: JWT and Noise sessions become invalid after rotation. Plan dual-key or maintenance windows when rotating.
+
+## Checklist
+
+- [ ] No plaintext production secrets in `docker-compose*.yml`, `*.exs`, or docs
+- [ ] Deploy pipeline injects secrets; images do not bake them in
+- [ ] `.env.example` lists every required variable with generation hints
+- [ ] Access to the secret store is least-privilege and audited

--- a/docs/SECURITY_REVIEW.md
+++ b/docs/SECURITY_REVIEW.md
@@ -10,16 +10,16 @@
 
 ## Alvorlighetsoversikt
 
-| ID | Alvorlighet | Funn |
-|----|-------------|------|
-| SEC-1 | 🔴 Kritisk | OTP-koder genereres med ikke-kryptografisk PRNG (`:rand.uniform`) |
-| SEC-2 | 🔴 Kritisk | Brutt tilgangskontroll i team-API — flere endepunkter mangler medlemskapssjekk (cross-tenant IDOR) |
-| SEC-3 | 🔴 Kritisk | Media-nedlasting aksepterer vilkårlig `object_key` (cross-tenant fil-tilgang) |
-| SEC-4 | 🟠 Høy | OTP-koder lagres som usaltet SHA-256 av 6-sifret rom (trivielt å brute-force ved DB-lekkasje) |
-| SEC-5 | 🟠 Høy | Ingen kanal-nivå autorisasjon — team-medlem kan lese/skrive i private kanaler de ikke er med i |
-| SEC-6 | 🟡 Medium | Bot-secret sammenlignes ikke i konstant tid (timing-angrep) |
-| SEC-7 | 🟡 Medium | Hardkodede secrets i `docker-compose.yml` (dekket av [#193](https://github.com/mikalv/msgr/issues/193)) |
-| SEC-8 | 🟢 Lav | Misvisende `authorization_schemes: [:noise]`-opsjon som er en no-op |
+| ID | Alvorlighet | Funn | Status |
+|----|-------------|------|--------|
+| SEC-1 | 🔴 Kritisk | OTP-koder genereres med ikke-kryptografisk PRNG (`:rand.uniform`) | ✅ Fikset i [#231](https://github.com/mikalv/msgr/pull/231) |
+| SEC-2 | 🔴 Kritisk | Brutt tilgangskontroll i team-API — flere endepunkter mangler medlemskapssjekk (cross-tenant IDOR) | ✅ Fikset i [#231](https://github.com/mikalv/msgr/pull/231) |
+| SEC-3 | 🔴 Kritisk | Media-nedlasting aksepterer vilkårlig `object_key` (cross-tenant fil-tilgang) | ✅ Fikset i [#231](https://github.com/mikalv/msgr/pull/231) |
+| SEC-4 | 🟠 Høy | OTP-koder lagres som usaltet SHA-256 av 6-sifret rom (trivielt å brute-force ved DB-lekkasje) | ✅ Fikset i [#231](https://github.com/mikalv/msgr/pull/231) (HMAC + attempt lockout) |
+| SEC-5 | 🟠 Høy | Ingen kanal-nivå autorisasjon — team-medlem kan lese/skrive i private kanaler de ikke er med i | ✅ Fikset i [#231](https://github.com/mikalv/msgr/pull/231) |
+| SEC-6 | 🟡 Medium | Bot-secret sammenlignes ikke i konstant tid (timing-angrep) | ✅ Fikset i [#231](https://github.com/mikalv/msgr/pull/231) |
+| SEC-7 | 🟡 Medium | Hardkodede secrets i `docker-compose.yml` (dekket av [#193](https://github.com/mikalv/msgr/issues/193)) | ✅ Secrets via `.env` + [docs/SECRET_MANAGEMENT.md](SECRET_MANAGEMENT.md) |
+| SEC-8 | 🟢 Lav | Misvisende `authorization_schemes: [:noise]`-opsjon som er en no-op | ✅ Fjernet no-op + oppdatert docstring |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up after [#231](https://github.com/mikalv/msgr/pull/231): finish remaining security-review items that are still code-fixable without infra/E2EE work.

Closes #193, closes #225.

### Changes

- **SEC-7 / #193** — Remove hardcoded `SECRET_KEY_BASE`, `SERVER_STATIC_KEY`, Postgres, Grafana, and OpenObserve passwords from `docker-compose.yml`. Compose now requires them via `.env` (`${VAR:?…}`). Expanded `.env.example` + new `docs/SECRET_MANAGEMENT.md` (local + prod / Vault / AWS SM).
- **SEC-8 / #225** — Drop no-op `authorization_schemes: [:noise]` from the `:actor` pipeline; update `CurrentActor` / `SessionContext` docs (JWT-only; no trusted `X-Account-Id` headers).
- **OTP lockout** — Increment `attempt_count` with atomic `UPDATE … inc` so concurrent wrong guesses cannot lose attempts.
- Status table in `docs/SECURITY_REVIEW.md` updated for SEC-1…SEC-8.

### Housekeeping (please close manually if still open)

These were already fixed in #231 but may not have auto-closed:
- #224 (SEC-4 HMAC), #226 (SEC-3 media), #227 (SEC-5 channel authz), #228 (SEC-6 secure_compare), #230 (SEC-1 RNG)

### Test plan

- [x] `mix test apps/msgr/test/messngr/auth_test.exs` — 7 tests, 0 failures
- [ ] `cp .env.example .env`, fill required secrets, `docker compose config` succeeds
- [ ] Compose without `.env` fails with clear missing-var errors

### Out of scope

E2EE (#195), DB HA/backup (#194/#192), virus scan (#197), external audit (#196), Vault deployment itself.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fba5c-2c71-7648-87aa-fcbd9133198a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fba5c-2c71-7648-87aa-fcbd9133198a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

