### PR TITLE
feat(media): ClamAV virus scan pipeline for team uploads (#197)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,5 +58,12 @@ MINIO_ENDPOINT=http://msgr-minio:9000
 MINIO_PUBLIC_HOST=localhost
 MINIO_PUBLIC_PORT=9000
 
+# --- ClamAV virus scanning -----------------------------------------------
+# When true, media downloads require a clean scan after POST .../media/:id/complete
+CLAMAV_ENABLED=true
+CLAMAV_HOST=clamav
+CLAMAV_PORT=3310
+CLAMAV_QUARANTINE_PREFIX=quarantine/
+
 # --- Legacy actor headers ------------------------------------------------
 MSGR_WEB_LEGACY_ACTOR_HEADERS=false

--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,9 @@ CLAMAV_ENABLED=true
 CLAMAV_HOST=clamav
 CLAMAV_PORT=3310
 CLAMAV_QUARANTINE_PREFIX=quarantine/
+# Bounded scan worker: max parallel scans + pending queue depth
+CLAMAV_MAX_CONCURRENCY=2
+CLAMAV_MAX_QUEUE=100
 
 # --- Legacy actor headers ------------------------------------------------
 MSGR_WEB_LEGACY_ACTOR_HEADERS=false

--- a/backend/apps/msgr/lib/msgr/application.ex
+++ b/backend/apps/msgr/lib/msgr/application.ex
@@ -36,6 +36,7 @@ defmodule Messngr.Application do
         Messngr.Metrics.Pipeline,
         Messngr.Repo,
         {Task.Supervisor, name: Messngr.TaskSupervisor},
+        Messngr.Media.VirusScan.Worker,
         Messngr.LinkUnfurl,
         {DNSCluster, query: Application.get_env(:msgr, :dns_cluster_query) || :ignore},
         {Phoenix.PubSub, name: Messngr.PubSub},

--- a/backend/apps/msgr/lib/msgr/media/storage.ex
+++ b/backend/apps/msgr/lib/msgr/media/storage.ex
@@ -85,6 +85,22 @@ defmodule Messngr.Media.Storage do
     URI.merge(public_endpoint, "#{bucket}/#{object_key}") |> to_string()
   end
 
+  @spec head_object(String.t(), String.t()) ::
+          {:ok, %{content_length: non_neg_integer() | nil}} | {:error, term()}
+  def head_object(bucket, object_key) do
+    case ExAws.S3.head_object(bucket, object_key) |> ExAws.request(internal_overrides()) do
+      {:ok, %{headers: headers}} ->
+        {:ok, %{content_length: content_length_from_headers(headers)}}
+
+      {:ok, response} when is_map(response) ->
+        headers = Map.get(response, :headers) || Map.get(response, "headers") || []
+        {:ok, %{content_length: content_length_from_headers(headers)}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   @spec get_object(String.t(), String.t()) :: {:ok, binary()} | {:error, term()}
   def get_object(bucket, object_key) do
     case ExAws.S3.get_object(bucket, object_key) |> ExAws.request(internal_overrides()) do
@@ -104,7 +120,11 @@ defmodule Messngr.Media.Storage do
   end
 
   @doc """
-  Moves an object into quarantine by copying then deleting the original.
+  Attempts to copy an object to a quarantine key, then always deletes the
+  original so infected bytes cannot keep being served from the live key.
+
+  Returns `:ok` when the quarantine copy succeeded. Returns `{:error, reason}`
+  when the copy failed (original is still deleted).
   """
   @spec quarantine_object(String.t(), String.t(), String.t()) :: :ok | {:error, term()}
   def quarantine_object(bucket, object_key, quarantine_key) do
@@ -118,12 +138,33 @@ defmodule Messngr.Media.Storage do
         :ok
 
       {:error, reason} ->
-        Logger.warning("Failed to quarantine object #{object_key}: #{inspect(reason)}")
-        # Still delete original so infected content cannot be served.
+        Logger.warning("Failed to copy object #{object_key} to quarantine: #{inspect(reason)}")
+        # Prefer deleting infected content over leaving it at the live key.
         _ = delete_object(bucket, object_key)
         {:error, reason}
     end
   end
+
+  defp content_length_from_headers(headers) when is_list(headers) do
+    headers
+    |> Enum.find_value(fn
+      {"Content-Length", value} -> parse_length(value)
+      {"content-length", value} -> parse_length(value)
+      _ -> nil
+    end)
+  end
+
+  defp content_length_from_headers(_), do: nil
+
+  defp parse_length(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, _} when int >= 0 -> int
+      _ -> nil
+    end
+  end
+
+  defp parse_length(value) when is_integer(value) and value >= 0, do: value
+  defp parse_length(_), do: nil
 
   @spec ensure_bucket!(String.t()) :: :ok
   def ensure_bucket!(bucket_name) do

--- a/backend/apps/msgr/lib/msgr/media/storage.ex
+++ b/backend/apps/msgr/lib/msgr/media/storage.ex
@@ -85,12 +85,43 @@ defmodule Messngr.Media.Storage do
     URI.merge(public_endpoint, "#{bucket}/#{object_key}") |> to_string()
   end
 
+  @spec get_object(String.t(), String.t()) :: {:ok, binary()} | {:error, term()}
+  def get_object(bucket, object_key) do
+    case ExAws.S3.get_object(bucket, object_key) |> ExAws.request(internal_overrides()) do
+      {:ok, %{body: body}} when is_binary(body) -> {:ok, body}
+      {:ok, %{body: body}} -> {:ok, IO.iodata_to_binary(body)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   @spec delete_object(String.t(), String.t()) :: :ok | {:error, term()}
   def delete_object(bucket, object_key) do
     case ExAws.S3.delete_object(bucket, object_key) |> ExAws.request(internal_overrides()) do
       {:ok, _} -> :ok
       {:error, {:http_error, 404, _}} -> :ok
       {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Moves an object into quarantine by copying then deleting the original.
+  """
+  @spec quarantine_object(String.t(), String.t(), String.t()) :: :ok | {:error, term()}
+  def quarantine_object(bucket, object_key, quarantine_key) do
+    copy =
+      ExAws.S3.put_object_copy(bucket, quarantine_key, bucket, object_key)
+      |> ExAws.request(internal_overrides())
+
+    case copy do
+      {:ok, _} ->
+        _ = delete_object(bucket, object_key)
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to quarantine object #{object_key}: #{inspect(reason)}")
+        # Still delete original so infected content cannot be served.
+        _ = delete_object(bucket, object_key)
+        {:error, reason}
     end
   end
 

--- a/backend/apps/msgr/lib/msgr/media/virus_scan.ex
+++ b/backend/apps/msgr/lib/msgr/media/virus_scan.ex
@@ -1,0 +1,244 @@
+defmodule Messngr.Media.VirusScan do
+  @moduledoc """
+  Orchestrates asynchronous virus scanning for team media uploads.
+
+  Flow:
+  1. Client finishes PUT → `complete_upload/2`
+  2. Status set to `:scanning` and a Task is enqueued
+  3. Object bytes are fetched from MinIO and scanned
+  4. Clean → `:clean`; infected → quarantine + `:infected`
+  """
+
+  require Logger
+
+  alias Messngr.Media.Storage
+  alias Messngr.Metrics.Pipeline
+
+  @doc """
+  Marks upload as scanning and enqueues an async scan job.
+
+  When scanning is disabled, the upload is marked `:clean` immediately.
+  """
+  def complete_upload(prefix, upload) when is_map(upload) do
+    if enabled?() do
+      with {:ok, upload} <-
+             media_upload().update(prefix, upload, %{
+               scan_status: :scanning,
+               threat_name: nil,
+               quarantine_key: nil
+             }) do
+        enqueue(prefix, upload.id)
+        {:ok, upload}
+      end
+    else
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      media_upload().update(prefix, upload, %{
+        scan_status: :clean,
+        scanned_at: now,
+        threat_name: nil
+      })
+    end
+  end
+
+  @doc "Enqueue scan for an existing upload id (idempotent enough for retries)."
+  def enqueue(prefix, upload_id) do
+    Task.Supervisor.start_child(Messngr.TaskSupervisor, fn ->
+      scan_upload(prefix, upload_id)
+    end)
+
+    :ok
+  end
+
+  @doc "Synchronously scan an upload (used by tests and the async worker)."
+  def scan_upload(prefix, upload_id) do
+    case media_upload().get_by_id(prefix, upload_id) do
+      nil ->
+        {:error, :not_found}
+
+      upload ->
+        do_scan(prefix, upload)
+    end
+  end
+
+  @doc """
+  Authorize download based on scan status.
+
+  Returns `:ok`, `{:error, :scan_pending}`, or `{:error, :infected}`.
+  When scanning is disabled, any non-infected upload is allowed.
+  """
+  def authorize_download(upload) when is_map(upload) do
+    status = Map.get(upload, :scan_status)
+
+    cond do
+      status == :clean ->
+        :ok
+
+      status == :infected ->
+        {:error, :infected}
+
+      not enabled?() ->
+        :ok
+
+      status in [:awaiting_upload, :scanning, :error] ->
+        {:error, :scan_pending}
+
+      true ->
+        {:error, :scan_pending}
+    end
+  end
+
+  defp do_scan(prefix, upload) do
+    started = System.monotonic_time(:millisecond)
+    bucket = Storage.bucket()
+
+    result =
+      case fetch_object(bucket, upload.object_key) do
+        {:ok, body} ->
+          scanner().scan_bytes(body, scanner_opts())
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+
+    duration = System.monotonic_time(:millisecond) - started
+    finish(prefix, upload, bucket, result, duration)
+  end
+
+  defp finish(prefix, upload, bucket, :clean, duration) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    {:ok, updated} =
+      media_upload().update(prefix, upload, %{
+        scan_status: :clean,
+        scanned_at: now,
+        threat_name: nil
+      })
+
+    emit_metric(duration, :clean, upload)
+    broadcast(prefix, updated)
+    {:ok, updated}
+  end
+
+  defp finish(prefix, upload, bucket, {:infected, threat}, duration) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    quarantine_key = quarantine_key(upload.object_key)
+
+    _ = quarantine_object(bucket, upload.object_key, quarantine_key)
+
+    {:ok, updated} =
+      media_upload().update(prefix, upload, %{
+        scan_status: :infected,
+        scanned_at: now,
+        threat_name: threat,
+        quarantine_key: quarantine_key
+      })
+
+    emit_metric(duration, :infected, upload, threat)
+    notify_detection(prefix, updated)
+    broadcast(prefix, updated)
+    {:ok, updated}
+  end
+
+  defp finish(prefix, upload, _bucket, {:error, reason}, duration) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    Logger.warning("media virus scan failed",
+      upload_id: upload.id,
+      object_key: upload.object_key,
+      reason: inspect(reason)
+    )
+
+    {:ok, updated} =
+      media_upload().update(prefix, upload, %{
+        scan_status: :error,
+        scanned_at: now
+      })
+
+    emit_metric(duration, :error, upload)
+    broadcast(prefix, updated)
+    {:error, reason}
+  end
+
+  # Runtime lookup avoids compile-time dependency on the Teams app.
+  defp media_upload, do: Teams.TenantModels.MediaUpload
+
+  defp fetch_object(bucket, object_key) do
+    case config(:fetch_object, nil) do
+      fun when is_function(fun, 2) -> fun.(bucket, object_key)
+      _ -> Storage.get_object(bucket, object_key)
+    end
+  end
+
+  defp quarantine_object(bucket, object_key, quarantine_key) do
+    case config(:quarantine_object, nil) do
+      fun when is_function(fun, 3) -> fun.(bucket, object_key, quarantine_key)
+      _ -> Storage.quarantine_object(bucket, object_key, quarantine_key)
+    end
+  end
+
+  defp quarantine_key(object_key) do
+    prefix = config(:quarantine_prefix, "quarantine/")
+    prefix = if String.ends_with?(prefix, "/"), do: prefix, else: prefix <> "/"
+    prefix <> object_key
+  end
+
+  defp notify_detection(prefix, upload) do
+    Logger.error("malware detected in media upload",
+      tenant_prefix: prefix,
+      upload_id: upload.id,
+      object_key: upload.object_key,
+      threat_name: upload.threat_name,
+      profile_id: upload.profile_id
+    )
+  end
+
+  defp broadcast(prefix, upload) do
+    # Best-effort realtime status for the uploader / team UIs.
+    # Topic is intentionally tenant-scoped via prefix in the payload.
+    if Process.whereis(MessngrWeb.Endpoint) do
+      MessngrWeb.Endpoint.broadcast("media:#{prefix}", "media:scan_complete", %{
+        upload_id: upload.id,
+        object_key: upload.object_key,
+        scan_status: upload.scan_status,
+        threat_name: upload.threat_name
+      })
+    end
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp emit_metric(duration_ms, result, upload, threat \\ nil) do
+    Pipeline.emit_media_scan(duration_ms, %{
+      result: result,
+      upload_id: upload.id,
+      content_type: upload.content_type,
+      threat_name: threat
+    })
+  rescue
+    _ -> :ok
+  end
+
+  defp scanner do
+    config(:scanner, Messngr.Media.VirusScan.Clamd)
+  end
+
+  defp scanner_opts do
+    [
+      host: config(:host, "127.0.0.1"),
+      port: config(:port, 3310),
+      timeout: config(:timeout, 60_000)
+    ]
+  end
+
+  defp enabled? do
+    config(:enabled, false)
+  end
+
+  defp config(key, default) do
+    Application.get_env(:msgr, __MODULE__, [])
+    |> Keyword.get(key, default)
+  end
+end

--- a/backend/apps/msgr/lib/msgr/media/virus_scan.ex
+++ b/backend/apps/msgr/lib/msgr/media/virus_scan.ex
@@ -5,7 +5,7 @@ defmodule Messngr.Media.VirusScan do
   Flow:
   1. Client finishes PUT → `complete_upload/2`
   2. Status set to `:scanning` and a Task is enqueued
-  3. Object bytes are fetched from MinIO and scanned
+  3. Object size is checked via HEAD, then bytes are fetched and scanned
   4. Clean → `:clean`; infected → quarantine + `:infected`
   """
 
@@ -13,6 +13,9 @@ defmodule Messngr.Media.VirusScan do
 
   alias Messngr.Media.Storage
   alias Messngr.Metrics.Pipeline
+
+  # Keep in sync with TeamMediaController upload limit.
+  @default_max_scan_bytes 50 * 1024 * 1024
 
   @doc """
   Marks upload as scanning and enqueues an async scan job.
@@ -24,6 +27,7 @@ defmodule Messngr.Media.VirusScan do
       with {:ok, upload} <-
              media_upload().update(prefix, upload, %{
                scan_status: :scanning,
+               scanned_at: nil,
                threat_name: nil,
                quarantine_key: nil
              }) do
@@ -93,7 +97,7 @@ defmodule Messngr.Media.VirusScan do
     bucket = Storage.bucket()
 
     result =
-      case fetch_object(bucket, upload.object_key) do
+      case fetch_object_for_scan(bucket, upload.object_key) do
         {:ok, body} ->
           scanner().scan_bytes(body, scanner_opts())
 
@@ -105,7 +109,7 @@ defmodule Messngr.Media.VirusScan do
     finish(prefix, upload, bucket, result, duration)
   end
 
-  defp finish(prefix, upload, bucket, :clean, duration) do
+  defp finish(prefix, upload, _bucket, :clean, duration) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
     {:ok, updated} =
@@ -122,16 +126,20 @@ defmodule Messngr.Media.VirusScan do
 
   defp finish(prefix, upload, bucket, {:infected, threat}, duration) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
-    quarantine_key = quarantine_key(upload.object_key)
+    qkey = quarantine_key(upload.object_key)
 
-    _ = quarantine_object(bucket, upload.object_key, quarantine_key)
+    stored_quarantine_key =
+      case quarantine_object(bucket, upload.object_key, qkey) do
+        :ok -> qkey
+        {:error, _} -> nil
+      end
 
     {:ok, updated} =
       media_upload().update(prefix, upload, %{
         scan_status: :infected,
         scanned_at: now,
         threat_name: threat,
-        quarantine_key: quarantine_key
+        quarantine_key: stored_quarantine_key
       })
 
     emit_metric(duration, :infected, upload, threat)
@@ -162,6 +170,49 @@ defmodule Messngr.Media.VirusScan do
 
   # Runtime lookup avoids compile-time dependency on the Teams app.
   defp media_upload, do: Teams.TenantModels.MediaUpload
+
+  defp fetch_object_for_scan(bucket, object_key) do
+    max_bytes = max_scan_bytes()
+
+    with :ok <- ensure_object_within_limit(bucket, object_key, max_bytes),
+         {:ok, body} <- fetch_object(bucket, object_key) do
+      if byte_size(body) > max_bytes do
+        # Client-declared size can lie; never scan oversized payloads in memory.
+        _ = delete_object(bucket, object_key)
+        {:error, :object_too_large}
+      else
+        {:ok, body}
+      end
+    end
+  end
+
+  defp ensure_object_within_limit(bucket, object_key, max_bytes) do
+    case head_object(bucket, object_key) do
+      {:ok, %{content_length: length}} when is_integer(length) and length > max_bytes ->
+        _ = delete_object(bucket, object_key)
+        {:error, :object_too_large}
+
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp delete_object(bucket, object_key) do
+    case config(:delete_object, nil) do
+      fun when is_function(fun, 2) -> fun.(bucket, object_key)
+      _ -> Storage.delete_object(bucket, object_key)
+    end
+  end
+
+  defp head_object(bucket, object_key) do
+    case config(:head_object, nil) do
+      fun when is_function(fun, 2) -> fun.(bucket, object_key)
+      _ -> Storage.head_object(bucket, object_key)
+    end
+  end
 
   defp fetch_object(bucket, object_key) do
     case config(:fetch_object, nil) do
@@ -231,6 +282,10 @@ defmodule Messngr.Media.VirusScan do
       port: config(:port, 3310),
       timeout: config(:timeout, 60_000)
     ]
+  end
+
+  defp max_scan_bytes do
+    config(:max_scan_bytes, @default_max_scan_bytes)
   end
 
   defp enabled? do

--- a/backend/apps/msgr/lib/msgr/media/virus_scan.ex
+++ b/backend/apps/msgr/lib/msgr/media/virus_scan.ex
@@ -24,15 +24,42 @@ defmodule Messngr.Media.VirusScan do
   """
   def complete_upload(prefix, upload) when is_map(upload) do
     if enabled?() do
-      with {:ok, upload} <-
-             media_upload().update(prefix, upload, %{
-               scan_status: :scanning,
-               scanned_at: nil,
-               threat_name: nil,
-               quarantine_key: nil
-             }) do
-        enqueue(prefix, upload.id)
-        {:ok, upload}
+      case media_upload().update(prefix, upload, %{
+             scan_status: :scanning,
+             scanned_at: nil,
+             threat_name: nil,
+             quarantine_key: nil
+           }) do
+        {:ok, updated} ->
+          case enqueue(prefix, updated.id) do
+            :ok ->
+              {:ok, updated}
+
+            {:error, :queue_full} ->
+              {:ok, _reverted} =
+                media_upload().update(prefix, updated, %{
+                  scan_status: :awaiting_upload,
+                  scanned_at: nil,
+                  threat_name: nil,
+                  quarantine_key: nil
+                })
+
+              {:error, :scan_queue_full}
+
+            {:error, :worker_unavailable} ->
+              {:ok, _reverted} =
+                media_upload().update(prefix, updated, %{
+                  scan_status: :awaiting_upload,
+                  scanned_at: nil,
+                  threat_name: nil,
+                  quarantine_key: nil
+                })
+
+              {:error, :scan_queue_full}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
       end
     else
       now = DateTime.utc_now() |> DateTime.truncate(:second)
@@ -45,13 +72,13 @@ defmodule Messngr.Media.VirusScan do
     end
   end
 
-  @doc "Enqueue scan for an existing upload id (idempotent enough for retries)."
-  def enqueue(prefix, upload_id) do
-    Task.Supervisor.start_child(Messngr.TaskSupervisor, fn ->
-      scan_upload(prefix, upload_id)
-    end)
+  @doc """
+  Enqueue scan for an existing upload id via the bounded worker queue.
 
-    :ok
+  Returns `:ok` or `{:error, :queue_full | :worker_unavailable}`.
+  """
+  def enqueue(prefix, upload_id) do
+    Messngr.Media.VirusScan.Worker.enqueue(prefix, upload_id)
   end
 
   @doc "Synchronously scan an upload (used by tests and the async worker)."

--- a/backend/apps/msgr/lib/msgr/media/virus_scan/clamd.ex
+++ b/backend/apps/msgr/lib/msgr/media/virus_scan/clamd.ex
@@ -1,0 +1,78 @@
+defmodule Messngr.Media.VirusScan.Clamd do
+  @moduledoc """
+  Minimal clamd TCP client using the INSTREAM protocol.
+  """
+
+  @behaviour Messngr.Media.VirusScan.Scanner
+
+  @default_chunk 65_536
+  @recv_timeout 60_000
+
+  @impl true
+  def scan_bytes(data, opts \\ []) when is_binary(data) do
+    host = Keyword.get(opts, :host) || config(:host, "127.0.0.1")
+    port = Keyword.get(opts, :port) || config(:port, 3310)
+    timeout = Keyword.get(opts, :timeout, @recv_timeout)
+
+    case :gen_tcp.connect(host_charlist(host), port, [:binary, active: false], timeout) do
+      {:ok, socket} ->
+        try do
+          with :ok <- :gen_tcp.send(socket, "zINSTREAM\0"),
+               :ok <- stream_chunks(socket, data),
+               :ok <- :gen_tcp.send(socket, <<0::32>>),
+               {:ok, response} <- :gen_tcp.recv(socket, 0, timeout) do
+            parse_response(response)
+          end
+        after
+          :gen_tcp.close(socket)
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp stream_chunks(_socket, <<>>), do: :ok
+
+  defp stream_chunks(socket, data) do
+    size = byte_size(data)
+    chunk_size = min(@default_chunk, size)
+    <<chunk::binary-size(chunk_size), rest::binary>> = data
+    packet = <<chunk_size::32, chunk::binary>>
+
+    case :gen_tcp.send(socket, packet) do
+      :ok -> stream_chunks(socket, rest)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp parse_response(response) when is_binary(response) do
+    trimmed = response |> to_string() |> String.trim()
+
+    cond do
+      String.contains?(trimmed, "OK") and not String.contains?(trimmed, "FOUND") ->
+        :clean
+
+      String.contains?(trimmed, "FOUND") ->
+        threat =
+          trimmed
+          |> String.replace(~r/^stream:\s*/i, "")
+          |> String.replace(~r/\s+FOUND$/i, "")
+          |> String.trim()
+
+        {:infected, threat}
+
+      true ->
+        {:error, {:unexpected_response, trimmed}}
+    end
+  end
+
+  defp host_charlist(host) when is_binary(host), do: String.to_charlist(host)
+  defp host_charlist(host) when is_list(host), do: host
+  defp host_charlist(host), do: host |> to_string() |> String.to_charlist()
+
+  defp config(key, default) do
+    Application.get_env(:msgr, Messngr.Media.VirusScan, [])
+    |> Keyword.get(key, default)
+  end
+end

--- a/backend/apps/msgr/lib/msgr/media/virus_scan/passthrough.ex
+++ b/backend/apps/msgr/lib/msgr/media/virus_scan/passthrough.ex
@@ -1,0 +1,10 @@
+defmodule Messngr.Media.VirusScan.Passthrough do
+  @moduledoc """
+  Test/dev scanner that always returns `:clean`.
+  """
+
+  @behaviour Messngr.Media.VirusScan.Scanner
+
+  @impl true
+  def scan_bytes(_data, _opts \\ []), do: :clean
+end

--- a/backend/apps/msgr/lib/msgr/media/virus_scan/scanner.ex
+++ b/backend/apps/msgr/lib/msgr/media/virus_scan/scanner.ex
@@ -1,0 +1,9 @@
+defmodule Messngr.Media.VirusScan.Scanner do
+  @moduledoc """
+  Behaviour for virus scanners used by `Messngr.Media.VirusScan`.
+  """
+
+  @type scan_result :: :clean | {:infected, String.t()} | {:error, term()}
+
+  @callback scan_bytes(binary(), keyword()) :: scan_result()
+end

--- a/backend/apps/msgr/lib/msgr/media/virus_scan/worker.ex
+++ b/backend/apps/msgr/lib/msgr/media/virus_scan/worker.ex
@@ -1,0 +1,179 @@
+defmodule Messngr.Media.VirusScan.Worker do
+  @moduledoc """
+  Bounded virus-scan job queue with concurrency limits.
+
+  Prevents authenticated clients from exhausting API/ClamAV resources by
+  flooding `complete` with unbounded `Task.Supervisor` workers.
+  """
+
+  use GenServer
+  require Logger
+
+  @default_max_concurrency 2
+  @default_max_queue 100
+
+  @type job :: {prefix :: String.t(), upload_id :: term()}
+
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Enqueue a scan job.
+
+  Returns:
+  - `:ok` when accepted (or already queued/running for the same upload)
+  - `{:error, :queue_full}` when the pending queue is at capacity
+  - `{:error, :worker_unavailable}` when the worker is not running
+  """
+  @spec enqueue(String.t(), term()) :: :ok | {:error, :queue_full | :worker_unavailable}
+  def enqueue(prefix, upload_id) when is_binary(prefix) do
+    case Process.whereis(__MODULE__) do
+      nil ->
+        {:error, :worker_unavailable}
+
+      pid ->
+        GenServer.call(pid, {:enqueue, prefix, upload_id}, 5_000)
+    end
+  end
+
+  @doc "Current queue depth and in-flight count (for tests/metrics)."
+  def stats do
+    case Process.whereis(__MODULE__) do
+      nil -> %{queued: 0, inflight: 0, max_concurrency: 0, max_queue: 0}
+      pid -> GenServer.call(pid, :stats)
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    {:ok,
+     %{
+       queue: :queue.new(),
+       queued: MapSet.new(),
+       inflight: %{},
+       inflight_ids: MapSet.new(),
+       max_concurrency: Keyword.get(opts, :max_concurrency),
+       max_queue: Keyword.get(opts, :max_queue)
+     }}
+  end
+
+  @impl true
+  def handle_call({:enqueue, prefix, upload_id}, _from, state) do
+    key = {prefix, upload_id}
+    {max_concurrency, max_queue} = limits(state)
+    capacity = max_concurrency + max_queue
+    load = map_size(state.inflight) + :queue.len(state.queue)
+
+    cond do
+      MapSet.member?(state.queued, key) or MapSet.member?(state.inflight_ids, key) ->
+        {:reply, :ok, state}
+
+      load >= capacity ->
+        Logger.warning("virus scan queue full",
+          queued: :queue.len(state.queue),
+          inflight: map_size(state.inflight),
+          max_queue: max_queue,
+          max_concurrency: max_concurrency
+        )
+
+        {:reply, {:error, :queue_full}, state}
+
+      true ->
+        state = %{
+          state
+          | queue: :queue.in(key, state.queue),
+            queued: MapSet.put(state.queued, key)
+        }
+
+        {:reply, :ok, drain(state)}
+    end
+  end
+
+  @impl true
+  def handle_call(:stats, _from, state) do
+    {max_concurrency, max_queue} = limits(state)
+
+    {:reply,
+     %{
+       queued: :queue.len(state.queue),
+       inflight: map_size(state.inflight),
+       max_concurrency: max_concurrency,
+       max_queue: max_queue
+     }, state}
+  end
+
+  @impl true
+  def handle_info({ref, _result}, state) when is_map_key(state.inflight, ref) do
+    Process.demonitor(ref, [:flush])
+    {:noreply, finish_job(state, ref)}
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    if Map.has_key?(state.inflight, ref) do
+      {:noreply, finish_job(state, ref)}
+    else
+      {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  defp finish_job(state, ref) do
+    {key, inflight} = Map.pop!(state.inflight, ref)
+
+    state = %{
+      state
+      | inflight: inflight,
+        inflight_ids: MapSet.delete(state.inflight_ids, key)
+    }
+
+    drain(state)
+  end
+
+  defp drain(state) do
+    {max_concurrency, _max_queue} = limits(state)
+
+    if map_size(state.inflight) >= max_concurrency do
+      state
+    else
+      case :queue.out(state.queue) do
+        {:empty, _queue} ->
+          state
+
+        {{:value, {prefix, upload_id} = key}, queue} ->
+          task =
+            Task.Supervisor.async_nolink(Messngr.TaskSupervisor, fn ->
+              Messngr.Media.VirusScan.scan_upload(prefix, upload_id)
+            end)
+
+          state = %{
+            state
+            | queue: queue,
+              queued: MapSet.delete(state.queued, key),
+              inflight: Map.put(state.inflight, task.ref, key),
+              inflight_ids: MapSet.put(state.inflight_ids, key)
+          }
+
+          drain(state)
+      end
+    end
+  end
+
+  defp limits(state) do
+    config = Application.get_env(:msgr, Messngr.Media.VirusScan, [])
+
+    max_concurrency =
+      state.max_concurrency ||
+        Keyword.get(config, :max_concurrency, @default_max_concurrency)
+
+    max_queue =
+      state.max_queue ||
+        Keyword.get(config, :max_queue, @default_max_queue)
+
+    {max(1, max_concurrency), max(0, max_queue)}
+  end
+end

--- a/backend/apps/msgr/lib/msgr/metrics/pipeline.ex
+++ b/backend/apps/msgr/lib/msgr/metrics/pipeline.ex
@@ -13,6 +13,7 @@ defmodule Messngr.Metrics.Pipeline do
   @delivery_rate_event [:msgr, :chat, :delivery, :rate]
   @app_start_event [:msgr, :app, :startup]
   @composer_event [:msgr, :composer, :render]
+  @media_scan_event [:msgr, :media, :scan, :stop]
 
   @doc """
   Starts the pipeline and attaches telemetry handlers.
@@ -33,7 +34,8 @@ defmodule Messngr.Metrics.Pipeline do
         {@delivery_latency_event, &handle_latency/4},
         {@delivery_rate_event, &handle_rate/4},
         {@app_start_event, &handle_app_start/4},
-        {@composer_event, &handle_composer/4}
+        {@composer_event, &handle_composer/4},
+        {@media_scan_event, &handle_media_scan/4}
       ]
       |> Enum.map(&attach_handler(&1, state))
 
@@ -78,6 +80,13 @@ defmodule Messngr.Metrics.Pipeline do
     :telemetry.execute(@composer_event, %{duration_ms: duration_ms}, metadata)
   end
 
+  @doc """
+  Emits a media virus-scan duration measurement.
+  """
+  def emit_media_scan(duration_ms, metadata \\ %{}) do
+    :telemetry.execute(@media_scan_event, %{duration_ms: duration_ms}, metadata)
+  end
+
   defp attach_handler({event, handler}, state) do
     id = System.unique_integer([:positive])
     :telemetry.attach({__MODULE__, id, event}, event, handler, state)
@@ -102,6 +111,10 @@ defmodule Messngr.Metrics.Pipeline do
 
   defp handle_composer(_event, %{duration_ms: duration}, metadata, %{reporter: reporter}) do
     report(reporter, :composer_render, %{duration_ms: duration}, metadata)
+  end
+
+  defp handle_media_scan(_event, %{duration_ms: duration}, metadata, %{reporter: reporter}) do
+    report(reporter, :media_scan, %{duration_ms: duration}, metadata)
   end
 
   defp report(reporter, metric, measurement, metadata) when is_atom(reporter) do

--- a/backend/apps/msgr_web/lib/msgr_web/controllers/fallback_controller.ex
+++ b/backend/apps/msgr_web/lib/msgr_web/controllers/fallback_controller.ex
@@ -32,6 +32,12 @@ defmodule MessngrWeb.FallbackController do
     |> json(%{error: "infected"})
   end
 
+  def call(conn, {:error, :scan_queue_full}) do
+    conn
+    |> put_status(:service_unavailable)
+    |> json(%{error: "scan_queue_full"})
+  end
+
   def call(conn, {:error, :too_many_attempts}) do
     conn
     |> put_status(:too_many_requests)

--- a/backend/apps/msgr_web/lib/msgr_web/controllers/fallback_controller.ex
+++ b/backend/apps/msgr_web/lib/msgr_web/controllers/fallback_controller.ex
@@ -20,6 +20,18 @@ defmodule MessngrWeb.FallbackController do
     |> json(%{error: "forbidden"})
   end
 
+  def call(conn, {:error, :scan_pending}) do
+    conn
+    |> put_status(:locked)
+    |> json(%{error: "scan_pending"})
+  end
+
+  def call(conn, {:error, :infected}) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{error: "infected"})
+  end
+
   def call(conn, {:error, :too_many_attempts}) do
     conn
     |> put_status(:too_many_requests)

--- a/backend/apps/msgr_web/lib/msgr_web/controllers/team_media_controller.ex
+++ b/backend/apps/msgr_web/lib/msgr_web/controllers/team_media_controller.ex
@@ -1,8 +1,9 @@
 defmodule MessngrWeb.TeamMediaController do
   use MessngrWeb, :controller
 
-  alias Teams.TenantModels.MediaUpload
   alias Messngr.Media.Storage
+  alias Messngr.Media.VirusScan
+  alias Teams.TenantModels.MediaUpload
 
   action_fallback MessngrWeb.FallbackController
 
@@ -42,7 +43,8 @@ defmodule MessngrWeb.TeamMediaController do
             object_key: object_key,
             content_type: content_type,
             filename: filename,
-            size: size
+            size: size,
+            scan_status: :awaiting_upload
           })
 
         # Generate presigned upload URL via Storage module
@@ -58,9 +60,41 @@ defmodule MessngrWeb.TeamMediaController do
             upload_url: upload_url,
             upload_headers: headers,
             upload_method: "PUT",
+            scan_status: upload.scan_status,
             expires_at: DateTime.to_iso8601(expires_at)
           }
         })
+    end
+  end
+
+  @doc """
+  POST /api/teams/:slug/media/:upload_id/complete — client finished PUT to MinIO.
+
+  Enqueues virus scan (or marks clean when scanning is disabled).
+  """
+  def complete(conn, %{"upload_id" => upload_id}) do
+    prefix = conn.assigns.tenant_prefix
+    profile = conn.assigns.current_team_profile
+
+    case MediaUpload.get_by_id(prefix, upload_id) do
+      nil ->
+        {:error, :not_found}
+
+      %MediaUpload{profile_id: profile_id} = upload when profile_id != profile.id ->
+        {:error, :forbidden}
+
+      %MediaUpload{scan_status: status} = upload
+      when status in [:scanning, :clean, :infected] ->
+        json(conn, %{data: upload_json(upload)})
+
+      %MediaUpload{} = upload ->
+        case VirusScan.complete_upload(prefix, upload) do
+          {:ok, updated} ->
+            json(conn, %{data: upload_json(updated)})
+
+          {:error, reason} ->
+            {:error, reason}
+        end
     end
   end
 
@@ -71,26 +105,43 @@ defmodule MessngrWeb.TeamMediaController do
     object_key = URI.decode(object_key_encoded)
     team_prefix = "teams/#{team.id}/"
 
-    cond do
-      not String.starts_with?(object_key, team_prefix) ->
-        {:error, :forbidden}
+    with :ok <- validate_team_prefix(object_key, team_prefix),
+         {:ok, upload} <- fetch_upload(prefix, object_key),
+         :ok <- VirusScan.authorize_download(upload) do
+      bucket = Storage.bucket()
 
-      is_nil(MediaUpload.get_by_object_key(prefix, object_key)) ->
-        {:error, :not_found}
+      %{url: url, expires_at: expires_at} =
+        Storage.presign_download(bucket, object_key)
 
-      true ->
-        bucket = Storage.bucket()
-
-        %{url: url, expires_at: expires_at} =
-          Storage.presign_download(bucket, object_key)
-
-        json(conn, %{
-          data: %{
-            download_url: url,
-            expires_at: DateTime.to_iso8601(expires_at)
-          }
-        })
+      json(conn, %{
+        data: %{
+          download_url: url,
+          expires_at: DateTime.to_iso8601(expires_at),
+          scan_status: upload.scan_status
+        }
+      })
     end
+  end
+
+  defp validate_team_prefix(object_key, team_prefix) do
+    if String.starts_with?(object_key, team_prefix), do: :ok, else: {:error, :forbidden}
+  end
+
+  defp fetch_upload(prefix, object_key) do
+    case MediaUpload.get_by_object_key(prefix, object_key) do
+      nil -> {:error, :not_found}
+      upload -> {:ok, upload}
+    end
+  end
+
+  defp upload_json(upload) do
+    %{
+      upload_id: upload.id,
+      object_key: upload.object_key,
+      scan_status: upload.scan_status,
+      threat_name: upload.threat_name,
+      scanned_at: upload.scanned_at && DateTime.to_iso8601(upload.scanned_at)
+    }
   end
 
   defp parse_size(nil), do: nil

--- a/backend/apps/msgr_web/lib/msgr_web/router.ex
+++ b/backend/apps/msgr_web/lib/msgr_web/router.ex
@@ -142,6 +142,7 @@ defmodule MessngrWeb.Router do
     get "/profiles/:id", TeamProfileController, :show
     put "/profiles/me", TeamProfileController, :update
     post "/media/presign", TeamMediaController, :presign
+    post "/media/:upload_id/complete", TeamMediaController, :complete
     get "/media/:object_key/url", TeamMediaController, :download_url
     post "/dms", TeamDmController, :create
 

--- a/backend/apps/msgr_web/test/msgr_web/controllers/team_media_virus_scan_test.exs
+++ b/backend/apps/msgr_web/test/msgr_web/controllers/team_media_virus_scan_test.exs
@@ -202,6 +202,52 @@ defmodule MessngrWeb.TeamMediaVirusScanTest do
     assert {:error, :infected} = VirusScan.authorize_download(%{upload | scan_status: :infected})
   end
 
+  test "complete rejects when scan queue is saturated", %{
+    conn: conn,
+    slug: slug,
+    prefix: prefix,
+    team: team,
+    profile: profile
+  } do
+    put_scan_env(
+      scanner: Messngr.Media.VirusScan.BlockingStub,
+      max_concurrency: 1,
+      max_queue: 0
+    )
+
+    {:ok, first} =
+      MediaUpload.create(prefix, %{
+        profile_id: profile.id,
+        object_key: "teams/#{team.id}/#{Ecto.UUID.generate()}/a.bin",
+        content_type: "application/octet-stream",
+        filename: "a.bin",
+        size: 1,
+        scan_status: :awaiting_upload
+      })
+
+    {:ok, second} =
+      MediaUpload.create(prefix, %{
+        profile_id: profile.id,
+        object_key: "teams/#{team.id}/#{Ecto.UUID.generate()}/b.bin",
+        content_type: "application/octet-stream",
+        filename: "b.bin",
+        size: 1,
+        scan_status: :awaiting_upload
+      })
+
+    first_resp = post(conn, "/api/teams/#{slug}/media/#{first.id}/complete")
+    assert json_response(first_resp, 200)["data"]["scan_status"] == "scanning"
+
+    # Give the worker a moment to start the blocking scan so capacity is consumed.
+    Process.sleep(50)
+
+    second_resp = post(conn, "/api/teams/#{slug}/media/#{second.id}/complete")
+    assert json_response(second_resp, 503)["error"] == "scan_queue_full"
+
+    reloaded = MediaUpload.get_by_id(prefix, second.id)
+    assert reloaded.scan_status == :awaiting_upload
+  end
+
   defp put_scan_env(overrides) do
     Application.put_env(
       :msgr,
@@ -215,7 +261,9 @@ defmodule MessngrWeb.TeamMediaVirusScanTest do
           quarantine_object: fn _b, _k, _q -> :ok end,
           delete_object: fn _b, _k -> :ok end,
           quarantine_prefix: "quarantine/",
-          max_scan_bytes: 50 * 1024 * 1024
+          max_scan_bytes: 50 * 1024 * 1024,
+          max_concurrency: 2,
+          max_queue: 100
         ],
         overrides
       )

--- a/backend/apps/msgr_web/test/msgr_web/controllers/team_media_virus_scan_test.exs
+++ b/backend/apps/msgr_web/test/msgr_web/controllers/team_media_virus_scan_test.exs
@@ -7,13 +7,15 @@ defmodule MessngrWeb.TeamMediaVirusScanTest do
   setup %{conn: conn} do
     ctx = setup_team(conn)
 
+    put_scan_env(
+      scanner: Messngr.Media.VirusScan.Passthrough,
+      quarantine_object: fn _b, _k, _q -> :ok end
+    )
+
     on_exit(fn ->
-      Application.put_env(:msgr, VirusScan,
-        enabled: true,
+      put_scan_env(
         scanner: Messngr.Media.VirusScan.Passthrough,
-        fetch_object: fn _b, _k -> {:ok, "test-bytes"} end,
-        quarantine_object: fn _b, _k, _q -> :ok end,
-        quarantine_prefix: "quarantine/"
+        quarantine_object: fn _b, _k, _q -> :ok end
       )
     end)
 
@@ -95,25 +97,26 @@ defmodule MessngrWeb.TeamMediaVirusScanTest do
         content_type: "application/pdf",
         filename: "doc.pdf",
         size: 10,
-        scan_status: :awaiting_upload
+        scan_status: :awaiting_upload,
+        scanned_at: DateTime.utc_now() |> DateTime.truncate(:second)
       })
 
     complete = post(conn, "/api/teams/#{slug}/media/#{upload.id}/complete")
     resp = json_response(complete, 200)
     assert resp["data"]["scan_status"] in ["scanning", "clean"]
 
-    Process.sleep(150)
-    reloaded = MediaUpload.get_by_id(prefix, upload.id)
-    assert reloaded.scan_status == :clean
+    # Retries clear stale scanned_at while scanning is in progress.
+    if resp["data"]["scan_status"] == "scanning" do
+      assert is_nil(resp["data"]["scanned_at"])
+    end
+
+    assert_scan_status(prefix, upload.id, :clean)
   end
 
   test "scan_upload quarantines infected files", %{prefix: prefix, team: team, profile: profile} do
-    Application.put_env(:msgr, VirusScan,
-      enabled: true,
+    put_scan_env(
       scanner: Messngr.Media.VirusScan.InfectedStub,
-      fetch_object: fn _b, _k -> {:ok, "eicar"} end,
-      quarantine_object: fn _b, _k, _q -> :ok end,
-      quarantine_prefix: "quarantine/"
+      quarantine_object: fn _b, _k, _q -> :ok end
     )
 
     {:ok, upload} =
@@ -132,6 +135,57 @@ defmodule MessngrWeb.TeamMediaVirusScanTest do
     assert String.starts_with?(updated.quarantine_key, "quarantine/")
   end
 
+  test "scan_upload omits quarantine_key when quarantine copy fails", %{
+    prefix: prefix,
+    team: team,
+    profile: profile
+  } do
+    put_scan_env(
+      scanner: Messngr.Media.VirusScan.InfectedStub,
+      quarantine_object: fn _b, _k, _q -> {:error, :copy_failed} end
+    )
+
+    {:ok, upload} =
+      MediaUpload.create(prefix, %{
+        profile_id: profile.id,
+        object_key: "teams/#{team.id}/#{Ecto.UUID.generate()}/eicar2.bin",
+        content_type: "application/octet-stream",
+        filename: "eicar2.bin",
+        size: 68,
+        scan_status: :scanning
+      })
+
+    assert {:ok, updated} = VirusScan.scan_upload(prefix, upload.id)
+    assert updated.scan_status == :infected
+    assert is_nil(updated.quarantine_key)
+  end
+
+  test "scan_upload rejects oversized objects before loading body", %{
+    prefix: prefix,
+    team: team,
+    profile: profile
+  } do
+    put_scan_env(
+      scanner: Messngr.Media.VirusScan.Passthrough,
+      head_object: fn _b, _k -> {:ok, %{content_length: 51 * 1024 * 1024}} end,
+      fetch_object: fn _b, _k -> flunk("must not fetch oversized object") end
+    )
+
+    {:ok, upload} =
+      MediaUpload.create(prefix, %{
+        profile_id: profile.id,
+        object_key: "teams/#{team.id}/#{Ecto.UUID.generate()}/huge.bin",
+        content_type: "application/octet-stream",
+        filename: "huge.bin",
+        size: 10,
+        scan_status: :scanning
+      })
+
+    assert {:error, :object_too_large} = VirusScan.scan_upload(prefix, upload.id)
+    reloaded = MediaUpload.get_by_id(prefix, upload.id)
+    assert reloaded.scan_status == :error
+  end
+
   test "authorize_download gates statuses", %{profile: profile, prefix: prefix, team: team} do
     {:ok, upload} =
       MediaUpload.create(prefix, %{
@@ -146,5 +200,42 @@ defmodule MessngrWeb.TeamMediaVirusScanTest do
     assert {:error, :scan_pending} = VirusScan.authorize_download(upload)
     assert :ok = VirusScan.authorize_download(%{upload | scan_status: :clean})
     assert {:error, :infected} = VirusScan.authorize_download(%{upload | scan_status: :infected})
+  end
+
+  defp put_scan_env(overrides) do
+    Application.put_env(
+      :msgr,
+      VirusScan,
+      Keyword.merge(
+        [
+          enabled: true,
+          scanner: Messngr.Media.VirusScan.Passthrough,
+          head_object: fn _b, _k -> {:ok, %{content_length: 10}} end,
+          fetch_object: fn _b, _k -> {:ok, "test-bytes"} end,
+          quarantine_object: fn _b, _k, _q -> :ok end,
+          delete_object: fn _b, _k -> :ok end,
+          quarantine_prefix: "quarantine/",
+          max_scan_bytes: 50 * 1024 * 1024
+        ],
+        overrides
+      )
+    )
+  end
+
+  defp assert_scan_status(prefix, upload_id, expected, attempts \\ 50) do
+    Enum.reduce_while(1..attempts, nil, fn _, _ ->
+      case MediaUpload.get_by_id(prefix, upload_id) do
+        %{scan_status: ^expected} = upload ->
+          {:halt, upload}
+
+        _ ->
+          Process.sleep(20)
+          {:cont, nil}
+      end
+    end)
+    |> case do
+      %{scan_status: ^expected} = upload -> upload
+      _ -> flunk("expected scan_status #{inspect(expected)} for #{upload_id}")
+    end
   end
 end

--- a/backend/apps/msgr_web/test/msgr_web/controllers/team_media_virus_scan_test.exs
+++ b/backend/apps/msgr_web/test/msgr_web/controllers/team_media_virus_scan_test.exs
@@ -1,0 +1,150 @@
+defmodule MessngrWeb.TeamMediaVirusScanTest do
+  use MessngrWeb.ConnCase, async: false
+
+  alias Messngr.Media.VirusScan
+  alias Teams.TenantModels.MediaUpload
+
+  setup %{conn: conn} do
+    ctx = setup_team(conn)
+
+    on_exit(fn ->
+      Application.put_env(:msgr, VirusScan,
+        enabled: true,
+        scanner: Messngr.Media.VirusScan.Passthrough,
+        fetch_object: fn _b, _k -> {:ok, "test-bytes"} end,
+        quarantine_object: fn _b, _k, _q -> :ok end,
+        quarantine_prefix: "quarantine/"
+      )
+    end)
+
+    %{
+      conn: ctx.conn,
+      slug: ctx.slug,
+      prefix: ctx.prefix,
+      team: ctx.team,
+      profile: ctx.team_profile
+    }
+  end
+
+  test "download blocked until scan is clean", %{
+    conn: conn,
+    slug: slug,
+    prefix: prefix,
+    team: team,
+    profile: profile
+  } do
+    object_key = "teams/#{team.id}/#{Ecto.UUID.generate()}/pending.pdf"
+
+    {:ok, upload} =
+      MediaUpload.create(prefix, %{
+        profile_id: profile.id,
+        object_key: object_key,
+        content_type: "application/pdf",
+        filename: "pending.pdf",
+        size: 10,
+        scan_status: :awaiting_upload
+      })
+
+    encoded = URI.encode(object_key, &URI.char_unreserved?/1)
+    pending = get(conn, "/api/teams/#{slug}/media/#{encoded}/url")
+    assert json_response(pending, 423)["error"] == "scan_pending"
+
+    {:ok, _} = MediaUpload.update(prefix, upload, %{scan_status: :clean})
+    allowed = get(conn, "/api/teams/#{slug}/media/#{encoded}/url")
+    assert json_response(allowed, 200)["data"]["download_url"]
+  end
+
+  test "download forbidden for infected media", %{
+    conn: conn,
+    slug: slug,
+    prefix: prefix,
+    team: team,
+    profile: profile
+  } do
+    object_key = "teams/#{team.id}/#{Ecto.UUID.generate()}/bad.pdf"
+
+    {:ok, _} =
+      MediaUpload.create(prefix, %{
+        profile_id: profile.id,
+        object_key: object_key,
+        content_type: "application/pdf",
+        filename: "bad.pdf",
+        size: 10,
+        scan_status: :infected,
+        threat_name: "Eicar-Test-Signature"
+      })
+
+    encoded = URI.encode(object_key, &URI.char_unreserved?/1)
+    conn = get(conn, "/api/teams/#{slug}/media/#{encoded}/url")
+    assert json_response(conn, 403)["error"] == "infected"
+  end
+
+  test "complete marks upload scanning then clean via passthrough", %{
+    conn: conn,
+    slug: slug,
+    prefix: prefix,
+    team: team,
+    profile: profile
+  } do
+    object_key = "teams/#{team.id}/#{Ecto.UUID.generate()}/doc.pdf"
+
+    {:ok, upload} =
+      MediaUpload.create(prefix, %{
+        profile_id: profile.id,
+        object_key: object_key,
+        content_type: "application/pdf",
+        filename: "doc.pdf",
+        size: 10,
+        scan_status: :awaiting_upload
+      })
+
+    complete = post(conn, "/api/teams/#{slug}/media/#{upload.id}/complete")
+    resp = json_response(complete, 200)
+    assert resp["data"]["scan_status"] in ["scanning", "clean"]
+
+    Process.sleep(150)
+    reloaded = MediaUpload.get_by_id(prefix, upload.id)
+    assert reloaded.scan_status == :clean
+  end
+
+  test "scan_upload quarantines infected files", %{prefix: prefix, team: team, profile: profile} do
+    Application.put_env(:msgr, VirusScan,
+      enabled: true,
+      scanner: Messngr.Media.VirusScan.InfectedStub,
+      fetch_object: fn _b, _k -> {:ok, "eicar"} end,
+      quarantine_object: fn _b, _k, _q -> :ok end,
+      quarantine_prefix: "quarantine/"
+    )
+
+    {:ok, upload} =
+      MediaUpload.create(prefix, %{
+        profile_id: profile.id,
+        object_key: "teams/#{team.id}/#{Ecto.UUID.generate()}/eicar.bin",
+        content_type: "application/octet-stream",
+        filename: "eicar.bin",
+        size: 68,
+        scan_status: :scanning
+      })
+
+    assert {:ok, updated} = VirusScan.scan_upload(prefix, upload.id)
+    assert updated.scan_status == :infected
+    assert updated.threat_name == "Eicar-Test-Signature"
+    assert String.starts_with?(updated.quarantine_key, "quarantine/")
+  end
+
+  test "authorize_download gates statuses", %{profile: profile, prefix: prefix, team: team} do
+    {:ok, upload} =
+      MediaUpload.create(prefix, %{
+        profile_id: profile.id,
+        object_key: "teams/#{team.id}/#{Ecto.UUID.generate()}/x.bin",
+        content_type: "application/octet-stream",
+        filename: "x.bin",
+        size: 1,
+        scan_status: :awaiting_upload
+      })
+
+    assert {:error, :scan_pending} = VirusScan.authorize_download(upload)
+    assert :ok = VirusScan.authorize_download(%{upload | scan_status: :clean})
+    assert {:error, :infected} = VirusScan.authorize_download(%{upload | scan_status: :infected})
+  end
+end

--- a/backend/apps/msgr_web/test/msgr_web/controllers/team_security_controller_test.exs
+++ b/backend/apps/msgr_web/test/msgr_web/controllers/team_security_controller_test.exs
@@ -220,7 +220,8 @@ defmodule MessngrWeb.TeamSecurityControllerTest do
           object_key: object_key,
           content_type: "application/pdf",
           filename: "ok.pdf",
-          size: 100
+          size: 100,
+          scan_status: :clean
         })
 
       encoded = URI.encode(object_key, &URI.char_unreserved?/1)

--- a/backend/apps/msgr_web/test/support/virus_scan_stubs.ex
+++ b/backend/apps/msgr_web/test/support/virus_scan_stubs.ex
@@ -1,0 +1,15 @@
+defmodule Messngr.Media.VirusScan.InfectedStub do
+  @moduledoc false
+  @behaviour Messngr.Media.VirusScan.Scanner
+
+  @impl true
+  def scan_bytes(_data, _opts \\ []), do: {:infected, "Eicar-Test-Signature"}
+end
+
+defmodule Messngr.Media.VirusScan.ErrorStub do
+  @moduledoc false
+  @behaviour Messngr.Media.VirusScan.Scanner
+
+  @impl true
+  def scan_bytes(_data, _opts \\ []), do: {:error, :boom}
+end

--- a/backend/apps/msgr_web/test/support/virus_scan_stubs.ex
+++ b/backend/apps/msgr_web/test/support/virus_scan_stubs.ex
@@ -13,3 +13,14 @@ defmodule Messngr.Media.VirusScan.ErrorStub do
   @impl true
   def scan_bytes(_data, _opts \\ []), do: {:error, :boom}
 end
+
+defmodule Messngr.Media.VirusScan.BlockingStub do
+  @moduledoc false
+  @behaviour Messngr.Media.VirusScan.Scanner
+
+  @impl true
+  def scan_bytes(_data, _opts \\ []) do
+    Process.sleep(2_000)
+    :clean
+  end
+end

--- a/backend/apps/teams/lib/teams/tenant_models/media_upload.ex
+++ b/backend/apps/teams/lib/teams/tenant_models/media_upload.ex
@@ -1,11 +1,13 @@
 defmodule Teams.TenantModels.MediaUpload do
   @moduledoc """
   Tenant-scoped media upload record.
-  The actual file lives in MinIO; this tracks metadata.
+  The actual file lives in MinIO; this tracks metadata and virus-scan state.
   """
 
   use Teams.Schema
   import Ecto.Changeset
+
+  @scan_statuses ~w(awaiting_upload scanning clean infected error)a
 
   schema "media_uploads" do
     belongs_to :profile, Teams.TenantModels.Profile
@@ -15,21 +17,47 @@ defmodule Teams.TenantModels.MediaUpload do
     field :filename, :string
     field :size, :integer
     field :checksum, :string
+    field :scan_status, Ecto.Enum, values: @scan_statuses, default: :awaiting_upload
+    field :scanned_at, :utc_datetime
+    field :threat_name, :string
+    field :quarantine_key, :string
 
     timestamps(type: :utc_datetime)
   end
 
+  def scan_statuses, do: @scan_statuses
+
   @doc false
   def changeset(upload, attrs) do
     upload
-    |> cast(attrs, [:profile_id, :object_key, :content_type, :filename, :size, :checksum])
+    |> cast(attrs, [
+      :profile_id,
+      :object_key,
+      :content_type,
+      :filename,
+      :size,
+      :checksum,
+      :scan_status,
+      :scanned_at,
+      :threat_name,
+      :quarantine_key
+    ])
     |> validate_required([:object_key])
+    |> validate_inclusion(:scan_status, @scan_statuses)
   end
 
   def create(prefix, attrs) do
+    attrs = Map.put_new(attrs, :scan_status, :awaiting_upload)
+
     %__MODULE__{}
     |> changeset(attrs)
     |> Teams.Repo.insert(prefix: prefix)
+  end
+
+  def update(prefix, %__MODULE__{} = upload, attrs) do
+    upload
+    |> changeset(attrs)
+    |> Teams.Repo.update(prefix: prefix)
   end
 
   def get_by_id(prefix, id) do
@@ -50,4 +78,8 @@ defmodule Teams.TenantModels.MediaUpload do
     from(u in __MODULE__, where: u.profile_id == ^profile_id, order_by: [desc: u.inserted_at])
     |> Teams.Repo.all(prefix: prefix)
   end
+
+  @doc "True when the object may be downloaded by clients."
+  def downloadable?(%__MODULE__{scan_status: :clean}), do: true
+  def downloadable?(_), do: false
 end

--- a/backend/apps/teams/priv/repo/tenant_migrations/20260801010000_add_scan_fields_to_media_uploads.exs
+++ b/backend/apps/teams/priv/repo/tenant_migrations/20260801010000_add_scan_fields_to_media_uploads.exs
@@ -1,0 +1,14 @@
+defmodule Teams.Repo.TenantMigrations.AddScanFieldsToMediaUploads do
+  use Ecto.Migration
+
+  def change do
+    alter table(:media_uploads) do
+      add :scan_status, :string, null: false, default: "awaiting_upload"
+      add :scanned_at, :utc_datetime
+      add :threat_name, :string
+      add :quarantine_key, :string
+    end
+
+    create index(:media_uploads, [:scan_status])
+  end
+end

--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -68,7 +68,8 @@ config :msgr, Messngr.Media.VirusScan,
   host: "127.0.0.1",
   port: 3310,
   scanner: Messngr.Media.VirusScan.Clamd,
-  quarantine_prefix: "quarantine/"
+  quarantine_prefix: "quarantine/",
+  max_scan_bytes: 50 * 1024 * 1024
 
 config :msgr, Messngr.Chat.WatcherPruner,
   enabled: true,

--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -63,6 +63,13 @@ config :msgr, Messngr.Media.RetentionPruner,
   interval_ms: :timer.minutes(10),
   batch_size: 100
 
+config :msgr, Messngr.Media.VirusScan,
+  enabled: false,
+  host: "127.0.0.1",
+  port: 3310,
+  scanner: Messngr.Media.VirusScan.Clamd,
+  quarantine_prefix: "quarantine/"
+
 config :msgr, Messngr.Chat.WatcherPruner,
   enabled: true,
   interval_ms: :timer.minutes(1)

--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -69,7 +69,9 @@ config :msgr, Messngr.Media.VirusScan,
   port: 3310,
   scanner: Messngr.Media.VirusScan.Clamd,
   quarantine_prefix: "quarantine/",
-  max_scan_bytes: 50 * 1024 * 1024
+  max_scan_bytes: 50 * 1024 * 1024,
+  max_concurrency: 2,
+  max_queue: 100
 
 config :msgr, Messngr.Chat.WatcherPruner,
   enabled: true,

--- a/backend/config/runtime.exs
+++ b/backend/config/runtime.exs
@@ -271,6 +271,35 @@ config :msgr,
        |> Keyword.put(:interval_ms, pruner_interval)
        |> Keyword.put(:batch_size, pruner_batch_size)
 
+virus_scan_config = Application.get_env(:msgr, Messngr.Media.VirusScan, [])
+
+clamav_enabled =
+  bool_env.(
+    System.get_env("CLAMAV_ENABLED"),
+    Keyword.get(virus_scan_config, :enabled, false)
+  )
+
+clamav_port =
+  int_env.(
+    System.get_env("CLAMAV_PORT"),
+    Keyword.get(virus_scan_config, :port, 3310),
+    "CLAMAV_PORT"
+  )
+
+config :msgr,
+       Messngr.Media.VirusScan,
+       virus_scan_config
+       |> Keyword.put(:enabled, clamav_enabled)
+       |> Keyword.put(:host, System.get_env("CLAMAV_HOST", Keyword.get(virus_scan_config, :host, "127.0.0.1")))
+       |> Keyword.put(:port, clamav_port)
+       |> Keyword.put(
+         :quarantine_prefix,
+         System.get_env(
+           "CLAMAV_QUARANTINE_PREFIX",
+           Keyword.get(virus_scan_config, :quarantine_prefix, "quarantine/")
+         )
+       )
+
 watcher_pruner_config = Application.get_env(:msgr, Messngr.Chat.WatcherPruner, [])
 
 watcher_pruner_enabled =

--- a/backend/config/runtime.exs
+++ b/backend/config/runtime.exs
@@ -286,6 +286,20 @@ clamav_port =
     "CLAMAV_PORT"
   )
 
+clamav_max_concurrency =
+  int_env.(
+    System.get_env("CLAMAV_MAX_CONCURRENCY"),
+    Keyword.get(virus_scan_config, :max_concurrency, 2),
+    "CLAMAV_MAX_CONCURRENCY"
+  )
+
+clamav_max_queue =
+  int_env.(
+    System.get_env("CLAMAV_MAX_QUEUE"),
+    Keyword.get(virus_scan_config, :max_queue, 100),
+    "CLAMAV_MAX_QUEUE"
+  )
+
 config :msgr,
        Messngr.Media.VirusScan,
        virus_scan_config
@@ -299,6 +313,8 @@ config :msgr,
            Keyword.get(virus_scan_config, :quarantine_prefix, "quarantine/")
          )
        )
+       |> Keyword.put(:max_concurrency, clamav_max_concurrency)
+       |> Keyword.put(:max_queue, clamav_max_queue)
 
 watcher_pruner_config = Application.get_env(:msgr, Messngr.Chat.WatcherPruner, [])
 

--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -57,6 +57,13 @@ config :msgr, Messngr.Noise.DevHandshake,
 
 config :msgr, Messngr.Chat.WatcherPruner, enabled: false
 
+config :msgr, Messngr.Media.VirusScan,
+  enabled: true,
+  scanner: Messngr.Media.VirusScan.Passthrough,
+  fetch_object: fn _bucket, _key -> {:ok, "test-bytes"} end,
+  quarantine_object: fn _bucket, _key, _qkey -> :ok end,
+  quarantine_prefix: "quarantine/"
+
 shared_repo_config =
   [
     username: System.get_env("POSTGRES_USERNAME", "postgres"),

--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -60,9 +60,11 @@ config :msgr, Messngr.Chat.WatcherPruner, enabled: false
 config :msgr, Messngr.Media.VirusScan,
   enabled: true,
   scanner: Messngr.Media.VirusScan.Passthrough,
+  head_object: fn _bucket, _key -> {:ok, %{content_length: 10}} end,
   fetch_object: fn _bucket, _key -> {:ok, "test-bytes"} end,
   quarantine_object: fn _bucket, _key, _qkey -> :ok end,
-  quarantine_prefix: "quarantine/"
+  quarantine_prefix: "quarantine/",
+  max_scan_bytes: 50 * 1024 * 1024
 
 shared_repo_config =
   [

--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -64,7 +64,9 @@ config :msgr, Messngr.Media.VirusScan,
   fetch_object: fn _bucket, _key -> {:ok, "test-bytes"} end,
   quarantine_object: fn _bucket, _key, _qkey -> :ok end,
   quarantine_prefix: "quarantine/",
-  max_scan_bytes: 50 * 1024 * 1024
+  max_scan_bytes: 50 * 1024 * 1024,
+  max_concurrency: 2,
+  max_queue: 100
 
 shared_repo_config =
   [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,6 +176,8 @@ services:
       CLAMAV_ENABLED: ${CLAMAV_ENABLED:-true}
       CLAMAV_HOST: ${CLAMAV_HOST:-clamav}
       CLAMAV_PORT: ${CLAMAV_PORT:-3310}
+      CLAMAV_MAX_CONCURRENCY: ${CLAMAV_MAX_CONCURRENCY:-2}
+      CLAMAV_MAX_QUEUE: ${CLAMAV_MAX_QUEUE:-100}
     working_dir: /app
     ports:
       - "127.0.0.1:4001:4000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,21 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
     restart: "no"
 
+  clamav:
+    image: clamav/clamav:1.4
+    container_name: msgr_clamav
+    ports:
+      - "127.0.0.1:3310:3310"
+    volumes:
+      - clamav_data:/var/lib/clamav
+    healthcheck:
+      test: ["CMD-SHELL", "clamdscan --ping 3 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+    restart: unless-stopped
+
   rust_gateway:
     build:
       context: ./rust-gateway
@@ -120,6 +135,8 @@ services:
         condition: service_healthy
       minio_init:
         condition: service_completed_successfully
+      clamav:
+        condition: service_started
     environment:
       MIX_ENV: prod
       PHX_SERVER: "true"
@@ -156,6 +173,9 @@ services:
       MINIO_PUBLIC_PORT: ${MINIO_PUBLIC_PORT:-9000}
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      CLAMAV_ENABLED: ${CLAMAV_ENABLED:-true}
+      CLAMAV_HOST: ${CLAMAV_HOST:-clamav}
+      CLAMAV_PORT: ${CLAMAV_PORT:-3310}
     working_dir: /app
     ports:
       - "127.0.0.1:4001:4000"
@@ -277,6 +297,7 @@ volumes:
   postgres_data:
   redis_data:
   minio_data:
+  clamav_data:
   elixir_deps:
   elixir_build:
   tailwind_cache:

--- a/docs/CODEBASE_ANALYSIS.md
+++ b/docs/CODEBASE_ANALYSIS.md
@@ -113,7 +113,7 @@
 | **Database HA** | Ingen Patroni/HA-konfigurasjon | P0 |
 | **Database Backup** | Ingen backup-strategi dokumentert/implementert | P0 |
 | **SSL/TLS Sertifikater** | Produksjon krever gyldige sertifikater, kun toggle-støtte | P0 |
-| **Virus/Malware Scanning** | Media pipeline uten virusskanning | P0 |
+| **Virus/Malware Scanning** | ClamAV + async scan/quarantine for team media (se `#197`) | P0 |
 | **Security Audit** | Ingen dokumentert sikkerhetsrevisjon | P0 |
 
 ### 3.2 🟠 Høy Prioritet


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements production-blocking virus/malware scanning for team media uploads.

Closes #197.

### Flow

1. `POST .../media/presign` creates `MediaUpload` with `scan_status: awaiting_upload`
2. Client PUTs to MinIO
3. `POST .../media/:upload_id/complete` marks `scanning` and enqueues async ClamAV scan
4. Clean → `clean` (download allowed); infected → quarantine + `infected` (download forbidden)
5. Unscanned / error → HTTP **423** `scan_pending`

### Changes

- Tenant migration: `scan_status`, `scanned_at`, `threat_name`, `quarantine_key`
- `Messngr.Media.VirusScan` + Clamd TCP `INSTREAM` client (swappable scanner behaviour)
- Storage helpers: `get_object/2`, `quarantine_object/3`
- docker-compose `clamav` service + `CLAMAV_*` env wiring
- Telemetry: `Pipeline.emit_media_scan/2` + error log on detection + `media:{prefix}` broadcast
- Tests for gating, complete→clean, infected quarantine

### Notes

- Async worker uses `Task.Supervisor` (same pattern as webhook dispatch). StoneMQ consumer can replace the enqueue later without changing status/API contracts.
- Personal-chat `Messngr.Media.Upload` path is out of scope for this PR (team media is the Flutter upload path).
- Clients must call `complete` after PUT; downloads of never-completed uploads stay locked when `CLAMAV_ENABLED=true`.

### Test plan

- [x] `mix test` team media virus scan + security + media controller — **23 tests, 0 failures**
- [ ] Local: set `CLAMAV_ENABLED=true`, `docker compose up clamav`, upload EICAR → expect `infected` + quarantine key
- [ ] Local: clean file → `complete` → download URL works
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fba5c-2c71-7648-87aa-fcbd9133198a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fba5c-2c71-7648-87aa-fcbd9133198a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

