### PR TITLE
docs: add Cursor Cloud backend dev environment instructions

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -50,3 +50,48 @@ Do not place or leave AI traces in this repository. I would lovely give you cred
 
 Use powershell for commands, never cmd.exe.
 
+## Cursor Cloud specific instructions
+
+Scope: the cloud VM is provisioned for the **Elixir/Phoenix backend** (`backend/`), which is
+the core product. The Flutter app, Rust gateway, and Go/Python bridges are not set up here.
+General backend docs live in `backend/README.md` and `docs/backend_setup.md`; the notes below
+only cover cloud-specific, non-obvious gotchas.
+
+### Toolchain (asdf)
+- Erlang/Elixir are managed by asdf. This repo requires **Elixir 1.16.2 / OTP 26.2** (what CI
+  uses). The committed `backend/.tool-versions` pins 1.19.1/OTP 28, which does **not** compile
+  the project (the `castle`/`n` dependency derives the release version from `git describe`, and
+  with no semver tags Mix rejects the bare short SHA as an invalid `Version`). The environment
+  forces the working toolchain via `ASDF_ERLANG_VERSION=26.2.5` and
+  `ASDF_ELIXIR_VERSION=1.16.2-otp-26` (exported in `~/.bashrc`). Do not `cd backend` and assume
+  the pinned 1.19.
+
+### Services
+- Only **PostgreSQL** is a hard boot dependency; Redis/StoneMQ/MinIO/ClamAV are optional or
+  best-effort in dev (MinIO `econnrefused` warnings at boot are harmless when object storage is
+  down). Start Postgres each session: `sudo pg_ctlcluster 16 main start` (or
+  `sudo service postgresql start`). The backend connects as `postgres`/`postgres` on
+  `localhost:5432`; dev DB `msgr_dev`, test DB `msgr_test`.
+
+### Run / DB setup
+- `mix setup` is **broken** here — its `cmd --app auth_provider mix setup` recursion hits the
+  git-version error above. Do the steps manually: `MIX_ENV=dev mix ecto.create` then
+  `mix ecto.migrate` (the app also auto-runs migrations on boot). Test DB:
+  `MIX_ENV=test mix ecto.create && MIX_ENV=test mix ecto.migrate`.
+- Dev server (from `backend/`): `PHX_LISTEN_IP=127.0.0.1 PORT=4000 SWOOSH_LOCAL_ADAPTER=true MIX_ENV=dev mix phx.server`.
+  With `SWOOSH_LOCAL_ADAPTER=true`, OTP emails go to the in-memory mailbox at
+  `http://localhost:4000/dev/mailbox` (JSON: `/dev/mailbox/json`). Health: `/health`,
+  LiveDashboard: `/dev/dashboard`.
+- OTP/account flow: `POST /api/v1/auth/challenge {channel,identifier}` → read code from the
+  mailbox → `POST /api/v1/auth/verify {challenge_id,code}` → creates the account and returns JWT
+  access/refresh tokens.
+
+### Tests / lint
+- Prometheus binds port **9568**. If the dev server is running, `mix test` fails with
+  `:eaddrinuse` — run tests with `PROMETHEUS_ENABLED=false` (or stop the dev server first).
+- Pre-existing on this branch: `apps/msgr/test/messngr/accounts/contact_conversation_flow_test.exs`
+  has a compile error (`^message.id` in a pattern) that blocks the whole `apps/msgr` suite; run
+  other files/apps individually until it is fixed.
+- Lint: `mix format --check-formatted`, `mix credo --strict`, `mix lint`. Some files are currently
+  unformatted and credo --strict reports many findings (pre-existing repo state).
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the Cursor Cloud development environment for the **Elixir/Phoenix backend** (the core product) and records the durable, non-obvious gotchas in `Agents.md` under `## Cursor Cloud specific instructions`.

No application code is changed — this PR only adds documentation. The toolchain install, Postgres setup, and the update script are captured in the VM environment (asdf + PostgreSQL), not in the repo.

## Environment that was set up

- **Erlang/OTP 26.2.5 + Elixir 1.16.2** via asdf (matches CI). The committed `backend/.tool-versions` pins 1.19.1/OTP 28, which does **not** compile the project — the `castle`/`n` dependency derives the release version from `git describe`, and with no semver tags Mix rejects the bare short SHA `976af39` as an invalid `Version`. The env forces the CI toolchain via `ASDF_ERLANG_VERSION` / `ASDF_ELIXIR_VERSION`.
- **PostgreSQL 16** (role `postgres`/`postgres`, DBs `msgr_dev` + `msgr_test`).
- Backend deps fetched, umbrella compiled, dev DB created + migrated (including this branch's e2ee tables).

## Verified working

- `mix compile` (whole umbrella) — succeeds.
- Dev server: `mix phx.server` → `GET /health` returns `{"status":"healthy"}` with all 3 Phoenix endpoints healthy.
- Hello-world core flow (new-user account creation): `POST /api/v1/auth/challenge` → OTP email in the dev mailbox → `POST /api/v1/auth/verify` → account created in Postgres + JWT tokens returned.
- Lint: `mix format --check-formatted` and `mix credo --strict` run (both surface pre-existing repo findings).
- Tests: `apps/msgr/test/messngr/auth_test.exs` → **7 tests, 0 failures** (run with `PROMETHEUS_ENABLED=false` when the dev server holds port 9568).

## Known pre-existing issues (not fixed here — out of scope)

- `mix setup` is broken (git-version error via the `castle`/`n` dep); use manual ecto steps.
- `apps/msgr/test/messngr/accounts/contact_conversation_flow_test.exs:47` has a compile error (`^message.id` in a pattern) blocking the full `apps/msgr` suite.
- Some files are unformatted on this branch.

## Demo

[msgr_backend_dev_server_running.mp4](https://cursor.com/agents/bc-08245f59-67ba-4e72-a8b6-e79bfc762f3b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmsgr_backend_dev_server_running.mp4)

Shows the running dev server: `/health` JSON, the Swoosh dev mailbox with the OTP login code, and the Phoenix LiveDashboard.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08245f59-67ba-4e72-a8b6-e79bfc762f3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08245f59-67ba-4e72-a8b6-e79bfc762f3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

